### PR TITLE
Add edit links on all pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,9 @@
 site_name: Frontira
 theme: material
 
+repo_name: 'qlik-ea/info'
+repo_url: 'https://github.com/qlik-ea/info'
+
 pages:
   - Home: index.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
This enables a small pen icon on all pages (upper right) that, when clicked, sends the user to GitHub and edit mode on that specific markdown file. Pretty nifty if people find anything.

Try it out: https://ca.qliktive.com/docs/edit-link