### PR TITLE
Link to other methods

### DIFF
--- a/docs/documentation/apis/qix-engine-doc.md
+++ b/docs/documentation/apis/qix-engine-doc.md
@@ -95,7 +95,9 @@ Checks if a given expression is valid.<br>The expression is correct if the param
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qErrorMsg` | string | &lt;message displayed when there is a syntax error&gt; || `qBadFieldNames` | array | [<br>{ "qFrom": &lt;position in the expression of the first character of the field name&gt;, "qCount": &lt;number of characters of the field name&gt; } ] || `qDangerousFieldNames` | array | `[]` |
+| `qErrorMsg` | string | &lt;message displayed when there is a syntax error&gt; |
+| `qBadFieldNames` | array | [<br>{ "qFrom": &lt;position in the expression of the first character of the field name&gt;, "qCount": &lt;number of characters of the field name&gt; } ] |
+| `qDangerousFieldNames` | array | `[]` |
 
 ## `CheckNumberOrExpression`
 
@@ -111,7 +113,8 @@ Checks if:<br>* A given expression is valid.<br>* A number is correct according 
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qErrorMsg` | string | &lt;message displayed when there is a syntax error&gt; || `qBadFieldNames` | array | [<br>{ "qFrom": &lt;position in the expression of the first character of the field name&gt;, "qCount": &lt;number of characters of the field name&gt; } ] |
+| `qErrorMsg` | string | &lt;message displayed when there is a syntax error&gt; |
+| `qBadFieldNames` | array | [<br>{ "qFrom": &lt;position in the expression of the first character of the field name&gt;, "qCount": &lt;number of characters of the field name&gt; } ] |
 
 ## `CheckScriptSyntax`
 
@@ -196,7 +199,7 @@ Clones a measure.<br><br>The identifier is set by the engine.
 
 ## `CloneObject`
 
-Clones root level objects, such as sheets and stories. The CloneObject method works for both app objects and child objects.<br>When you clone an object that contains children, the children are cloned as well.<br>If you for example want to clone a visualization, you must provide the qID of the root object, in this case the sheet since CloneObject clones root level objects.<br>It is not possible to clone a session object.<br><br>The identifier is set by the engine.
+Clones root level objects, such as sheets and stories. The [`CloneObject`](#cloneobject) method works for both app objects and child objects.<br>When you clone an object that contains children, the children are cloned as well.<br>If you for example want to clone a visualization, you must provide the qID of the root object, in this case the sheet since [`CloneObject`](#cloneobject) clones root level objects.<br>It is not possible to clone a session object.<br><br>The identifier is set by the engine.
 
 **Parameters:**
 
@@ -212,7 +215,7 @@ Clones root level objects, such as sheets and stories. The CloneObject method wo
 
 ## `CommitDraft`
 
-Commits the draft of an object that was previously created by invoking the _CreateDraft method_.<br>Committing a draft replaces the corresponding published object.
+Commits the draft of an object that was previously created by invoking the [`CreateDraft`](#createdraft) method.<br>Committing a draft replaces the corresponding published object.
 
 **Parameters:**
 
@@ -236,7 +239,8 @@ Creates a bookmark.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qInfo` | object | `{"qId":"<identifier of the bookmark>","qType":"Bookmark"}` || `qReturn` | object | { "qType": "GenericBookmark", "qHandle":  &lt;handle of the bookmark&gt; } |
+| `qInfo` | object | `{"qId":"<identifier of the bookmark>","qType":"Bookmark"}` |
+| `qReturn` | object | { "qType": "GenericBookmark", "qHandle":  &lt;handle of the bookmark&gt; } |
 
 ## `CreateConnection`
 
@@ -268,11 +272,12 @@ Creates a master dimension.<br>A master dimension is stored in the library of an
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qInfo` | object | `{"qId":"<identifier of the dimension>","qType":"Dimension"}` || `qReturn` | object | { "qType": "GenericDimension", "qHandle": &lt;handle of the dimension&gt; } |
+| `qInfo` | object | `{"qId":"<identifier of the dimension>","qType":"Dimension"}` |
+| `qReturn` | object | { "qType": "GenericDimension", "qHandle": &lt;handle of the dimension&gt; } |
 
 ## `CreateDraft`
 
-Creates a draft of an object.<br>This method can be used to create a draft of a sheet or a story that is published. This is a way to continue working on a sheet or a story that is published.<br>Replace the published object by the content of the draft by invoking the _CommitDraft method_.<br><br>The identifier is set by the engine.
+Creates a draft of an object.<br>This method can be used to create a draft of a sheet or a story that is published. This is a way to continue working on a sheet or a story that is published.<br>Replace the published object by the content of the draft by invoking the [`CommitDraft`](#commitdraft) method.<br><br>The identifier is set by the engine.
 
 **Parameters:**
 
@@ -300,7 +305,8 @@ Creates a master measure.<br>A master measure is stored in the library of an app
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qInfo` | object | `{"qId":"<identifier of the measure>","qType":"Measure"}` || `qReturn` | object | { "qType": "GenericMeasure", "qHandle":  &lt;handle of the measure&gt; } |
+| `qInfo` | object | `{"qId":"<identifier of the measure>","qType":"Measure"}` |
+| `qReturn` | object | { "qType": "GenericMeasure", "qHandle":  &lt;handle of the measure&gt; } |
 
 ## `CreateObject`
 
@@ -316,7 +322,8 @@ Creates a generic object at app level. For more information on generic objects, 
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qInfo` | object | `{"qId":"<identifier of the new object>","qType":"<type of the new object>"}` || `qReturn` | object | { "qType": "GenericObject", "qHandle": &lt;handle of the new object&gt; } |
+| `qInfo` | object | `{"qId":"<identifier of the new object>","qType":"<type of the new object>"}` |
+| `qReturn` | object | { "qType": "GenericObject", "qHandle": &lt;handle of the new object&gt; } |
 
 ## `CreateSessionObject`
 
@@ -352,7 +359,7 @@ Creates a transient variable.<br>To set some properties to the variable, use the
 
 ## `CreateVariable`
 
-Creates a variable.<br>This method is deprecated (not recommended to use). Use _CreateVariableEx method_ instead. 
+Creates a variable.<br>This method is deprecated (not recommended to use). Use [`CreateVariableEx`](#createvariableex) method instead. 
 
 **Parameters:**
 
@@ -368,7 +375,7 @@ Creates a variable.<br>This method is deprecated (not recommended to use). Use _
 
 ## `CreateVariableEx`
 
-Creates a variable.<br>To create a variable via a script, you need to use the _SetScript method_. For more information, see _Create a variable_.<br>To set some properties to the variable, use the _SetProperties method_. In a published app, only transient variables can be created. See _CreateSessionVariable method_. <br><br>
+Creates a variable.<br>To create a variable via a script, you need to use the [`SetScript`](#setscript) method. For more information, see _Create a variable_.<br>To set some properties to the variable, use the _SetProperties method_. In a published app, only transient variables can be created. See [`CreateSessionVariable`](#createsessionvariable) method. <br><br>
 
 **Parameters:**
 
@@ -380,7 +387,8 @@ Creates a variable.<br>To create a variable via a script, you need to use the _S
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qInfo` | object | Identifier and type of the object. || `qReturn` | object | _None available._ |
+| `qInfo` | object | Identifier and type of the object. |
+| `qReturn` | object | _None available._ |
 
 ## `DeleteConnection`
 
@@ -509,7 +517,7 @@ Removes a transient variable.<br><br>The operation is successful if **qSuccess**
 
 ## `DestroyVariableById`
 
-Removes a variable.<br>Script-defined variables cannot be removed using the _DestroyVariableById method_ or the _DestroyVariableByName method_. For more information, see _Remove a variable_.<br><br>The operation is successful if **qSuccess** is set to true. 
+Removes a variable.<br>Script-defined variables cannot be removed using the [`DestroyVariableById`](#destroyvariablebyid) method or the [`DestroyVariableByName`](#destroyvariablebyname) method. For more information, see _Remove a variable_.<br><br>The operation is successful if **qSuccess** is set to true. 
 
 **Parameters:**
 
@@ -525,7 +533,7 @@ Removes a variable.<br>Script-defined variables cannot be removed using the _Des
 
 ## `DestroyVariableByName`
 
-Removes a variable.<br>Script-defined variables cannot be removed using the _DestroyVariableById method_ or the _DestroyVariableByName method_. For more information, see _Remove a variable_.<br><br>The operation is successful if **qSuccess** is set to true. 
+Removes a variable.<br>Script-defined variables cannot be removed using the [`DestroyVariableById`](#destroyvariablebyid) method or the [`DestroyVariableByName`](#destroyvariablebyname) method. For more information, see _Remove a variable_.<br><br>The operation is successful if **qSuccess** is set to true. 
 
 **Parameters:**
 
@@ -660,7 +668,7 @@ _No return values._
 
 ## `ForwardCount`
 
-Returns the number of entries on the Forward stack.
+Returns the number of entries on the [`Forward`](#forward) stack.
 
 _No parameters._
 
@@ -865,7 +873,8 @@ Retrieves the values of the specified table of a database for a ODBC, OLEDB or 
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qPreview` | array | List the values in the table. || `qRowCount` | integer | _None available._ |
+| `qPreview` | array | List the values in the table. |
+| `qRowCount` | integer | _None available._ |
 
 ## `GetDatabaseTables`
 
@@ -1011,7 +1020,8 @@ Lists the fields of a table for a folder connection.<br><br>
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qFields` | array | List of the tables. || `qFormatSpec` | string | List of format specification items, within brackets.<br>Examples of specification items:<br>* file type<br>* embedded labels, no labels<br>* table is &lt;table name&gt; |
+| `qFields` | array | List of the tables. |
+| `qFormatSpec` | string | List of format specification items, within brackets.<br>Examples of specification items:<br>* file type<br>* embedded labels, no labels<br>* table is &lt;table name&gt; |
 
 ## `GetFileTablePreview`
 
@@ -1030,7 +1040,8 @@ Lists the values in a table for a folder connection.<br><br>
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qPreview` | array | List of the tables. || `qFormatSpec` | string | List of format specification items, within brackets.<br>Examples of specification items:<br>* file type<br>* embedded labels, no labels<br>* table is &lt;table name&gt; |
+| `qPreview` | array | List of the tables. |
+| `qFormatSpec` | string | List of format specification items, within brackets.<br>Examples of specification items:<br>* file type<br>* embedded labels, no labels<br>* table is &lt;table name&gt; |
 
 ## `GetFileTables`
 
@@ -1109,7 +1120,7 @@ Returns the content of a library.<br><br>
 
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
-| `qName` | string | Yes | Name of the content library.<br>It corresponds to the property _qContentLibraryListItem/qName_ returned by the _GetContentLibraries method_. |
+| `qName` | string | Yes | Name of the content library.<br>It corresponds to the property _qContentLibraryListItem/qName_ returned by the [`GetContentLibraries`](#getcontentlibraries) method. |
 
 **Returns:**
 
@@ -1161,7 +1172,7 @@ Retrieves any fields that match all or one of the specified tags in the data mod
 
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
-| `qTags` | array | Yes | List of tags.<br>The _GetMatchingFields_ method looks for fields that match one or all of the tags in this list, depending on the value of _qMatchingFieldMode_ . |
+| `qTags` | array | Yes | List of tags.<br>The [`GetMatchingFields`](#getmatchingfields) method looks for fields that match one or all of the tags in this list, depending on the value of _qMatchingFieldMode_ . |
 | `qMatchingFieldMode` | string | No | Matching field mode.<br><br>The default value is 0. |
 
 **Returns:**
@@ -1188,7 +1199,7 @@ Returns the handle of a measure.
 
 ## `GetMediaList`
 
-Lists the media files.<br>This method is deprecated (not recommended to use). Use _GetLibraryContent method_ instead. 
+Lists the media files.<br>This method is deprecated (not recommended to use). Use [`GetLibraryContent`](#getlibrarycontent) method instead. 
 
 _No parameters._
 
@@ -1196,7 +1207,8 @@ _No parameters._
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qList` | object | Information about the media files. || `qReturn` | boolean | Is set to true if the operation is successful. |
+| `qList` | object | Information about the media files. |
+| `qReturn` | boolean | Is set to true if the operation is successful. |
 
 ## `GetObject`
 
@@ -1291,7 +1303,8 @@ Returns:<br>* The list of tables in an app and the fields inside each table.<br>
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qtr` | array | List of tables. || `qk` | array | List of keys. |
+| `qtr` | array | List of tables. |
+| `qk` | array | List of keys. |
 
 ## `GetTextMacros`
 
@@ -1307,7 +1320,7 @@ _No parameters._
 
 ## `GetVariable`
 
-Gets the handle of a variable.<br>This method is deprecated (not recommended to use). Use _GetVariableById method_ or _GetVariableByName method_ instead. 
+Gets the handle of a variable.<br>This method is deprecated (not recommended to use). Use [`GetVariableById`](#getvariablebyid) method or [`GetVariableByName`](#getvariablebyname) method instead. 
 
 **Parameters:**
 
@@ -1412,7 +1425,7 @@ _No return values._
 
 ## `ModifyConnection`
 
-Updates a connection.<br>The identifier of a connection cannot be updated. qType cannot be modified with the ModifyConnection method.
+Updates a connection.<br>The identifier of a connection cannot be updated. qType cannot be modified with the [`ModifyConnection`](#modifyconnection) method.
 
 **Parameters:**
 
@@ -1463,7 +1476,7 @@ _No return values._
 
 ## `RemoveVariable`
 
-Removes a variable.<br>This method is deprecated (not recommended to use). Use _DestroyVariableById method_ or _DestroyVariableByName method_ instead. 
+Removes a variable.<br>This method is deprecated (not recommended to use). Use [`DestroyVariableById`](#destroyvariablebyid) method or [`DestroyVariableByName`](#destroyvariablebyname) method instead. 
 
 **Parameters:**
 
@@ -1507,7 +1520,7 @@ _No return values._
 
 ## `SearchAssociations`
 
-Returns the search matches for one or more search terms.<br>The search results depend on the search context.<br>_SearchCombinationOptions_<br>This method is deprecated (not recommended to use). Use _SearchResults method_ instead. <br><br>
+Returns the search matches for one or more search terms.<br>The search results depend on the search context.<br>_SearchCombinationOptions_<br>This method is deprecated (not recommended to use). Use [`SearchResults`](#searchresults) method instead. <br><br>
 
 **Parameters:**
 

--- a/docs/documentation/apis/qix-engine-genericderivedfields.md
+++ b/docs/documentation/apis/qix-engine-genericderivedfields.md
@@ -17,7 +17,8 @@ _No details._
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qFields` | object | _None available._ || `qReturn` | boolean | _None available._ |
+| `qFields` | object | _None available._ |
+| `qReturn` | boolean | _None available._ |
 
 ## `GetDerivedFieldData`
 

--- a/docs/documentation/apis/qix-engine-genericobject.md
+++ b/docs/documentation/apis/qix-engine-genericobject.md
@@ -31,7 +31,7 @@ _No return values._
 
 ## `ApplyPatches`
 
-Applies a patch to the properties of an object. Allows an update to some of the properties.<br>It is possible to apply a patch to the properties of a generic object, that is not persistent. Such a patch is called a soft patch.<br>In that case, the result of the operation on the properties (add, remove or delete) is not shown when doing _GetProperties_ , and only a _GetLayout_ call shows the result of the operation.<br>Properties that are not persistent are called soft properties. Once the engine session is over, soft properties are cleared.<br>Soft properties apply only to generic objects. Applying a patch takes less time than resetting all the properties.
+Applies a patch to the properties of an object. Allows an update to some of the properties.<br>It is possible to apply a patch to the properties of a generic object, that is not persistent. Such a patch is called a soft patch.<br>In that case, the result of the operation on the properties (add, remove or delete) is not shown when doing [`GetProperties`](#getproperties) , and only a [`GetLayout`](#getlayout) call shows the result of the operation.<br>Properties that are not persistent are called soft properties. Once the engine session is over, soft properties are cleared.<br>Soft properties apply only to generic objects. Applying a patch takes less time than resetting all the properties.
 
 **Parameters:**
 
@@ -144,7 +144,8 @@ Creates a generic object that is a child of another generic object.<br>It is pos
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qInfo` | object | `{"qId":"<identifier of the child>","qType":"<type of the child>"}` || `qReturn` | object | { "qType": "GenericObject", "qHandle": &lt;handle of the child&gt; } |
+| `qInfo` | object | `{"qId":"<identifier of the child>","qType":"<type of the child>"}` |
+| `qReturn` | object | { "qType": "GenericObject", "qHandle": &lt;handle of the child&gt; } |
 
 ## `DestroyAllChildren`
 
@@ -281,7 +282,8 @@ Exports the data of any generic object to an Excel file or a open XML file. If t
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qUrl` | string | &lt;url of the exported file&gt; || `qWarnings` | array | `[1000]` |
+| `qUrl` | string | &lt;url of the exported file&gt; |
+| `qWarnings` | array | `[1000]` |
 
 ## `GetChild`
 
@@ -337,7 +339,7 @@ _No parameters._
 
 ## `GetHyperCubeBinnedData`
 
-This method supports data binning.<br>When a generic object with two or three measures and one dimension contains a lot of data, groups of points (for example, cells) can be rendered instead of points.<br>A zone of interest can be refined (for zooming in) up to a maximum refinement level (set in the _qQueryLevel_ parameter) or coarsened (for zoom out).<br>The grid of cells is adaptive (not static), meaning that it adapts to different length scales.<br>The _GetHyperCubeBinnedData_ method gives information about the adaptive grid and the values of the generic object.<br>The number of points in a cell and the coordinates (expressed in the measure range) of each cell are returned.<br>Dimension values and measure values are rendered at point level (highest detailed level).<br>The generic object should contain two or three measures and one dimension. When the refinement is high, the first two measures are represented on the x-axis and on the y-axis, while the third measure is visualized as color or point size.<br><br>
+This method supports data binning.<br>When a generic object with two or three measures and one dimension contains a lot of data, groups of points (for example, cells) can be rendered instead of points.<br>A zone of interest can be refined (for zooming in) up to a maximum refinement level (set in the _qQueryLevel_ parameter) or coarsened (for zoom out).<br>The grid of cells is adaptive (not static), meaning that it adapts to different length scales.<br>The [`GetHyperCubeBinnedData`](#gethypercubebinneddata) method gives information about the adaptive grid and the values of the generic object.<br>The number of points in a cell and the coordinates (expressed in the measure range) of each cell are returned.<br>Dimension values and measure values are rendered at point level (highest detailed level).<br>The generic object should contain two or three measures and one dimension. When the refinement is high, the first two measures are represented on the x-axis and on the y-axis, while the third measure is visualized as color or point size.<br><br>
 
 **Parameters:**
 
@@ -346,7 +348,7 @@ This method supports data binning.<br>When a generic object with two or three me
 | `qPath` | string | Yes | Path to the definition of the object.<br>For example, _/qHyperCubeDef_ . |
 | `qPages` | array | Yes | Array of pages to retrieve.<br>Since the generic object contains two measures and one dimension, _qWidth_ should be set to 3.<br>If the value of a measure is Null, the value cannot be rendered. Therefore, the number of elements rendered in a page can be less than the number defined in the property _qHeight_ . |
 | `qViewport` | object | Yes | Defines the canvas and the zoom level.<br>This parameter is not yet used and is optional. |
-| `qDataRanges` | array | Yes | Range of the data to render.<br>This range applies to the measure values.<br>The lowest and highest values of a measure can be retrieved by using the _GetLayout method_ (in _/qHyperCube/qMeasureInfo_ ). |
+| `qDataRanges` | array | Yes | Range of the data to render.<br>This range applies to the measure values.<br>The lowest and highest values of a measure can be retrieved by using the [`GetLayout`](#getlayout) method (in _/qHyperCube/qMeasureInfo_ ). |
 | `qMaxNbrCells` | integer | Yes | Maximum number of cells in the grid. |
 | `qQueryLevel` | integer | Yes | Level of details. The higher the level, the more detailed information you get (zoom-in).<br>When the number of points to render falls below a certain threshold, the values are no longer rendered as cells but as points.<br>The query level should be no greater than 20. |
 | `qBinningMethod` | integer | Yes | Selects the algorithm.<br>The default value is 0.<br>One of:<br>* 0: Adaptive grid<br>* 1: Hexagonal grid<br>* 2: Uniform grid |
@@ -373,7 +375,8 @@ Retrieves and packs compressed hypercube and axis data. It is possible to retrie
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qDataPages` | array | Array of pages to retrieve.<br>The dimension values and the measure values. || `qAxisData` | object | List of x-axis data including name, ticks and tags.<br>Only days are returned, not time. |
+| `qDataPages` | array | Array of pages to retrieve.<br>The dimension values and the measure values. |
+| `qAxisData` | object | List of x-axis data including name, ticks and tags.<br>Only days are returned, not time. |
 
 ## `GetHyperCubeData`
 
@@ -477,7 +480,7 @@ _No parameters._
 
 ## `GetLayout`
 
-Evaluates an object and displays its properties including the dynamic properties.<br>If the member _delta_ is set to true in the request object, only the delta is evaluated. A _GetLayout_ call on a generic object, returns up to one level down in the hierarchy.<br><br>
+Evaluates an object and displays its properties including the dynamic properties.<br>If the member _delta_ is set to true in the request object, only the delta is evaluated. A [`GetLayout`](#getlayout) call on a generic object, returns up to one level down in the hierarchy.<br><br>
 
 _No parameters._
 
@@ -518,7 +521,7 @@ Retrieves the values of a list object.<br>A data set is returned.
 
 ## `GetProperties`
 
-Returns the identifier, the type and the properties of the object.<br>Because it is not mandatory to set all properties when you define an object, the _GetProperties_ method may show properties that were not set. In that case, default values are given.<br>If the object contains some soft properties, the soft properties are not returned by the _GetProperties_ method. Use the _GetEffectiveProperties method_ instead.<br>If the object is linked to another object, the properties of the linking object are not returned by the _GetProperties_ method. Use the _GetEffectiveProperties method_ instead.<br>If the member delta is set to true in the request object, only the delta is retrieved.<br>The following is always returned in the output:
+Returns the identifier, the type and the properties of the object.<br>Because it is not mandatory to set all properties when you define an object, the [`GetProperties`](#getproperties) method may show properties that were not set. In that case, default values are given.<br>If the object contains some soft properties, the soft properties are not returned by the [`GetProperties`](#getproperties) method. Use the [`GetEffectiveProperties`](#geteffectiveproperties) method instead.<br>If the object is linked to another object, the properties of the linking object are not returned by the [`GetProperties`](#getproperties) method. Use the [`GetEffectiveProperties`](#geteffectiveproperties) method instead.<br>If the member delta is set to true in the request object, only the delta is retrieved.<br>The following is always returned in the output:
 
 _No parameters._
 
@@ -820,7 +823,7 @@ _No return values._
 
 ## `SetFullPropertyTree`
 
-Sets the properties of:<br>* A generic object.<br>* The children of the generic object.<br>* The bookmarks/embedded snapshots of the generic object.<br><br>If the _SetFullPropertyTree method_ is asked to set some properties to a child that does not exist, it creates the child. The type of an object cannot be updated.
+Sets the properties of:<br>* A generic object.<br>* The children of the generic object.<br>* The bookmarks/embedded snapshots of the generic object.<br><br>If the [`SetFullPropertyTree`](#setfullpropertytree) method is asked to set some properties to a child that does not exist, it creates the child. The type of an object cannot be updated.
 
 **Parameters:**
 

--- a/docs/documentation/apis/qix-engine-genericvariable.md
+++ b/docs/documentation/apis/qix-engine-genericvariable.md
@@ -78,7 +78,7 @@ _No return values._
 
 ## `SetProperties`
 
-Sets some properties for a variable.<br>The identifier of a variable cannot be modified. You cannot update the properties of a script-defined variable using the _SetProperties method_. 
+Sets some properties for a variable.<br>The identifier of a variable cannot be modified. You cannot update the properties of a script-defined variable using the [`SetProperties`](#setproperties) method. 
 
 **Parameters:**
 

--- a/docs/documentation/apis/qix-engine-global.md
+++ b/docs/documentation/apis/qix-engine-global.md
@@ -57,14 +57,14 @@ _No return values._
 
 ## `ConfigureReload`
 
-Configures the engine's behavior during a reload.<br>The _ConfigureReload method_ should be run before the _DoReload method_. 
+Configures the engine's behavior during a reload.<br>The [`ConfigureReload`](#configurereload) method should be run before the _DoReload method_. 
 
 **Parameters:**
 
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
 | `qCancelOnScriptError` | boolean | Yes | If set to true, the script execution is halted on error.<br>Otherwise, the engine continues the script execution.<br>This parameter is relevant only if the variable _ErrorMode_ is set to 1. |
-| `qUseErrorData` | boolean | Yes | If set to true, any script execution error is returned in _qErrorData_ by the _GetProgress method_. |
+| `qUseErrorData` | boolean | Yes | If set to true, any script execution error is returned in _qErrorData_ by the [`GetProgress`](#getprogress) method. |
 | `qInteractOnError` | boolean | Yes | If set to true, the script execution is halted on error and the engine is waiting for an interaction to be performed. If the result from the interaction is 1 ( _qDef.qResult_ is 1), the engine continues the script execution otherwise the execution is halted.<br>This parameter is relevant only if the variable _ErrorMode_ is set to 1 and the script is run in debug mode ( _qDebug_ is set to true when calling the _DoReload method_ ). |
 
 _No return values._
@@ -79,7 +79,7 @@ Copies an app that is in the Qlik Sense repository.<br>The engine copies the app
 | ---- | ---- | --------- | ----------- |
 | `qTargetAppId` | string | Yes | Identifier (GUID) of the app entity in the Qlik Sense repository.<br>The app entity must have been previously created by the Qlik Sense Repository Service API. |
 | `qSrcAppId` | string | Yes | Identifier (GUID) of the source app in the Qlik Sense repository. |
-| `qIds` | array | Yes | Array of QRS identifiers.<br>The list of all the objects in the app to be copied must be given. This list must contain the GUIDs of all these objects.<br>If the list of the QRS identifiers is empty, the _CopyApp_ method copies all objects to the target app.<br>Script-defined variables are automatically copied when copying an app. To be able to copy variables not created via script, the GUID of each variable must be provided in the list of QRS identifiers.<br>To get the QRS identifiers of the objects in an app, you can use the QRS API. The GET method (from the QRS API) returns the identifiers of the objects in the app.<br>The following example returns the QRS identifiers of all the objects in a specified app:<br>GET /qrs/app/9c3f8634-6191-4a34-a114-a39102058d13<br>Where<br>_9c3f8634-6191-4a34-a114-a39102058d13_ is the identifier of the app. |
+| `qIds` | array | Yes | Array of QRS identifiers.<br>The list of all the objects in the app to be copied must be given. This list must contain the GUIDs of all these objects.<br>If the list of the QRS identifiers is empty, the [`CopyApp`](#copyapp) method copies all objects to the target app.<br>Script-defined variables are automatically copied when copying an app. To be able to copy variables not created via script, the GUID of each variable must be provided in the list of QRS identifiers.<br>To get the QRS identifiers of the objects in an app, you can use the QRS API. The GET method (from the QRS API) returns the identifiers of the objects in the app.<br>The following example returns the QRS identifiers of all the objects in a specified app:<br>GET /qrs/app/9c3f8634-6191-4a34-a114-a39102058d13<br>Where<br>_9c3f8634-6191-4a34-a114-a39102058d13_ is the identifier of the app. |
 
 **Returns:**
 
@@ -118,7 +118,8 @@ Creates an app.<br><br>
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qSuccess` | boolean | True or false || `qAppId` | string | One of:<br>* Path and name of the app (Qlik Sense Desktop)<br>* GUID (Qlik Sense Enterprise) |
+| `qSuccess` | boolean | True or false |
+| `qAppId` | string | One of:<br>* Path and name of the app (Qlik Sense Desktop)<br>* GUID (Qlik Sense Enterprise) |
 
 ## `CreateDocEx`
 
@@ -138,7 +139,8 @@ Creates an app and opens an engine session.<br>This operation is possible only i
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qDocId` | string | &lt;path and name of the app&gt; || `qReturn` | object | { "qType": "Doc", "qHandle": &lt;handle of the app&gt; } |
+| `qDocId` | string | &lt;path and name of the app&gt; |
+| `qReturn` | object | { "qType": "Doc", "qHandle": &lt;handle of the app&gt; } |
 
 ## `CreateDocument`
 
@@ -148,7 +150,7 @@ _No details._
 
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
-| `qattr` | undefined | Yes | _None available._ |
+| `qattr` | _unknown_ | Yes | _None available._ |
 
 **Returns:**
 
@@ -166,7 +168,8 @@ _No parameters._
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qSessionAppId` | string | &lt;Identifier of the session app&gt; || `qReturn` | object | { "qType": "Doc", "qHandle": &lt;Handle of the session app&gt; }<br>The identifier of the session app is composed of the prefix _SessionApp__ and of a GUID. |
+| `qSessionAppId` | string | &lt;Identifier of the session app&gt; |
+| `qReturn` | object | { "qType": "Doc", "qHandle": &lt;Handle of the session app&gt; }<br>The identifier of the session app is composed of the prefix _SessionApp__ and of a GUID. |
 
 ## `CreateSessionAppFromApp`
 
@@ -176,13 +179,14 @@ Creates a session app from a source app.<br>The following applies:<br>* The obje
 
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
-| `qSrcAppId` | string | Yes | App identifier of the source app.<br>It corresponds to _qAppId_ returned by the _CreateApp method_ when creating the source app. |
+| `qSrcAppId` | string | Yes | App identifier of the source app.<br>It corresponds to _qAppId_ returned by the [`CreateApp`](#createapp) method when creating the source app. |
 
 **Returns:**
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qSessionAppId` | string | &lt;Identifier of the session app&gt; || `qReturn` | object | { "qType": "Doc", "qHandle": &lt;Handle of the session app&gt; }<br>The identifier of the session app is composed of the prefix _SessionApp__ and of a GUID. |
+| `qSessionAppId` | string | &lt;Identifier of the session app&gt; |
+| `qReturn` | object | { "qType": "Doc", "qHandle": &lt;Handle of the session app&gt; }<br>The identifier of the session app is composed of the prefix _SessionApp__ and of a GUID. |
 
 ## `DeleteApp`
 
@@ -262,7 +266,7 @@ Retrieves the meta data of an app.
 
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
-| `qAppID` | string | Yes | Identifier of the app, as returned by the _CreateApp method_.<br>One of:<br>* Path and name of the app ()<br>* GUID (Qlik Sense Enterprise) |
+| `qAppID` | string | Yes | Identifier of the app, as returned by the [`CreateApp`](#createapp) method.<br>One of:<br>* Path and name of the app ()<br>* GUID (Qlik Sense Enterprise) |
 
 **Returns:**
 
@@ -284,7 +288,7 @@ _No parameters._
 
 ## `GetBNF`
 
-Gets the current Backus-Naur Form (BNF) grammar of the Qlik engine scripting language. The BNF rules define the syntax for the script statements and the script or chart functions.<br>In the Qlik engine BNF grammar, a token is a string of one or more characters that is significant as a group. For example, a token could be a function name, a number, a letter, a parenthesis, and so on.<br>This method is deprecated (not recommended for use). Use the _GetBaseBNF method_ instead. 
+Gets the current Backus-Naur Form (BNF) grammar of the Qlik engine scripting language. The BNF rules define the syntax for the script statements and the script or chart functions.<br>In the Qlik engine BNF grammar, a token is a string of one or more characters that is significant as a group. For example, a token could be a function name, a number, a letter, a parenthesis, and so on.<br>This method is deprecated (not recommended for use). Use the [`GetBaseBNF`](#getbasebnf) method instead. 
 
 **Parameters:**
 
@@ -312,7 +316,8 @@ Gets the current Backus-Naur Form (BNF) grammar of the Qlik engine scripting lan
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qBnfDefs` | array | Description of the scripting language grammar. || `qBnfHash` | string | A string hash of the BNF definition. |
+| `qBnfDefs` | array | Description of the scripting language grammar. |
+| `qBnfHash` | string | A string hash of the BNF definition. |
 
 ## `GetBaseBNFHash`
 
@@ -344,7 +349,8 @@ Gets the current Backus-Naur Form (BNF) grammar of the Qlik engine scripting lan
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qBnfStr` | string | Description of the scripting language grammar. || `qBnfHash` | string | A string hash of the BNF definition. |
+| `qBnfStr` | string | Description of the scripting language grammar. |
+| `qBnfHash` | string | A string hash of the BNF definition. |
 
 ## `GetConfiguration`
 
@@ -366,7 +372,7 @@ List the custom connectors available in the system.
 
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
-| `qReloadList` | boolean | No | Sets if the list of custom connectors should be reloaded or not.<br>If set to false, only the connectors that were returned the previous time are returned. If new connectors have been added since the last call to the _GetCustomConnectors_ method was made, the new connectors are not returned.<br>If set to true, the _GetCustomConnectors_ method looks for new connectors in the file system.<br>The default value is false. |
+| `qReloadList` | boolean | No | Sets if the list of custom connectors should be reloaded or not.<br>If set to false, only the connectors that were returned the previous time are returned. If new connectors have been added since the last call to the [`GetCustomConnectors`](#getcustomconnectors) method was made, the new connectors are not returned.<br>If set to true, the [`GetCustomConnectors`](#getcustomconnectors) method looks for new connectors in the file system.<br>The default value is false. |
 
 **Returns:**
 
@@ -404,7 +410,7 @@ _No parameters._
 
 ## `GetDocList`
 
-Returns the list of apps.<br>In Qlik Sense Enterprise:<br>The list is generated by the QRS. The GetDocList method only returns documents the current user is allowed to access.<br>In Qlik Sense Desktop:<br>The apps are located in _C:\Users\ &lt;user name&gt;\Documents\Qlik\Sense\Apps_ .
+Returns the list of apps.<br>In Qlik Sense Enterprise:<br>The list is generated by the QRS. The [`GetDocList`](#getdoclist) method only returns documents the current user is allowed to access.<br>In Qlik Sense Desktop:<br>The apps are located in _C:\Users\ &lt;user name&gt;\Documents\Qlik\Sense\Apps_ .
 
 _No parameters._
 
@@ -450,7 +456,7 @@ Returns the files and folders located at a specified path.
 
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
-| `qPath` | string | Yes | Absolute or relative path.<br>Relative paths are relative to the default _Apps_ folder.<br>In Qlik Sense Enterprise:<br>The list is generated by the QRS. The GetDocList method only returns documents the current user is allowed to access.<br>In Qlik Sense Desktop:<br>The apps are located in _C:\Users\ &lt;user name&gt;\Documents\Qlik\Sense\Apps_ . |
+| `qPath` | string | Yes | Absolute or relative path.<br>Relative paths are relative to the default _Apps_ folder.<br>In Qlik Sense Enterprise:<br>The list is generated by the QRS. The [`GetDocList`](#getdoclist) method only returns documents the current user is allowed to access.<br>In Qlik Sense Desktop:<br>The apps are located in _C:\Users\ &lt;user name&gt;\Documents\Qlik\Sense\Apps_ . |
 
 **Returns:**
 
@@ -476,7 +482,7 @@ Gets the list of all the script functions.
 
 ## `GetInteract`
 
-Retrieves information on the user interaction that is requested by the engine.<br>Engine can request user interactions only during script reload and when the reload is performed in debug mode ( _qDebug_ is set to true when using the _DoReload method_ ).<br>When running reload in debug mode, the engine pauses the script execution to receive data about user interaction. The engine can pause:<br>* Before executing a new script statement.<br>* When an error occurs while executing the script.<br>* When the script execution is finished.<br><br>To know if the engine is paused and waits for a response to an interaction request, the _GetProgress method_ should be used. The engine waits for a response if the property _qUserInteractionWanted_ is set to true in the response of the _GetProgress_ request.
+Retrieves information on the user interaction that is requested by the engine.<br>Engine can request user interactions only during script reload and when the reload is performed in debug mode ( _qDebug_ is set to true when using the _DoReload method_ ).<br>When running reload in debug mode, the engine pauses the script execution to receive data about user interaction. The engine can pause:<br>* Before executing a new script statement.<br>* When an error occurs while executing the script.<br>* When the script execution is finished.<br><br>To know if the engine is paused and waits for a response to an interaction request, the [`GetProgress`](#getprogress) method should be used. The engine waits for a response if the property _qUserInteractionWanted_ is set to true in the response of the [`GetProgress`](#getprogress) request.
 
 **Parameters:**
 
@@ -488,7 +494,8 @@ Retrieves information on the user interaction that is requested by the engine.<b
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `qDef` | object | Information to set up the user interaction.<br>Indicates which kind of interaction is wanted. || `qReturn` | boolean | _None available._ |
+| `qDef` | object | Information to set up the user interaction.<br>Indicates which kind of interaction is wanted. |
+| `qReturn` | boolean | _None available._ |
 
 ## `GetLogicalDriveStrings`
 
@@ -702,7 +709,7 @@ _No parameters._
 
 ## `OpenDoc`
 
-Opens an app and checks if the app needs to be migrated (if the app is deprecated).<br>The _OpenDoc method_ compares the version of the app with the version of Qlik Sense and migrates the app to the current version of Qlik Sense if necessary. Once the migration is done, the app is opened.<br>If no migration is needed, the app is opened immediately.<br>The following applies:<br>* The app version is lower than 0.95: no migration is done. Apps older than the version 0.95 are not supported.<br>* The app version is at least 0.95 and less than the Qlik Sense version: the app is migrated and then opened.<br>* Qlik Sense and the app have the same version: the app is opened, no migration is needed.<br><br>If the app is read-only, the app migration cannot occur. An error message is sent.<br><br>
+Opens an app and checks if the app needs to be migrated (if the app is deprecated).<br>The [`OpenDoc`](#opendoc) method compares the version of the app with the version of Qlik Sense and migrates the app to the current version of Qlik Sense if necessary. Once the migration is done, the app is opened.<br>If no migration is needed, the app is opened immediately.<br>The following applies:<br>* The app version is lower than 0.95: no migration is done. Apps older than the version 0.95 are not supported.<br>* The app version is at least 0.95 and less than the Qlik Sense version: the app is migrated and then opened.<br>* Qlik Sense and the app have the same version: the app is opened, no migration is needed.<br><br>If the app is read-only, the app migration cannot occur. An error message is sent.<br><br>
 
 **Parameters:**
 
@@ -722,7 +729,7 @@ Opens an app and checks if the app needs to be migrated (if the app is deprecate
 
 ## `ProductVersion`
 
-Returns the Qlik Sense version number.<br>This method is deprecated (not recommended for use). Use the _EngineVersion method_ instead. 
+Returns the Qlik Sense version number.<br>This method is deprecated (not recommended for use). Use the [`EngineVersion`](#engineversion) method instead. 
 
 _No parameters._
 
@@ -755,7 +762,7 @@ _No details._
 | Name | Type | Mandatory | Description |
 | ---- | ---- | --------- | ----------- |
 | `qdocId` | string | Yes | _None available._ |
-| `qpublish` | undefined | Yes | _None available._ |
+| `qpublish` | _unknown_ | Yes | _None available._ |
 
 _No return values._
 
@@ -773,7 +780,7 @@ _No parameters._
 
 ## `QvVersion`
 
-Returns the Qlik Sense version number.<br>This method is deprecated (not recommended to use). Use the _EngineVersion method_ instead. 
+Returns the Qlik Sense version number.<br>This method is deprecated (not recommended to use). Use the [`EngineVersion`](#engineversion) method instead. 
 
 _No parameters._
 

--- a/docs/documentation/apis/qix-engine-variable.md
+++ b/docs/documentation/apis/qix-engine-variable.md
@@ -5,7 +5,7 @@ _API specification for version 12.97.0._
 
 ## `ForceContent`
 
-Sets the value of a dual variable overriding any input constraints.<br>This method is deprecated (not recommended to use). Use _SetProperties method_ instead. The _ForceContent method_ does not evaluate any expression. 
+Sets the value of a dual variable overriding any input constraints.<br>This method is deprecated (not recommended to use). Use _SetProperties method_ instead. The [`ForceContent`](#forcecontent) method does not evaluate any expression. 
 
 **Parameters:**
 


### PR DESCRIPTION
Now links to other methods within the same QIX structure (e.g. Doc method A which mentions Doc method B is now a proper link).

Also fixed an issue with markdown tables.

Review:
https://ca.qliktive.com/docs/linkify-methods/documentation/apis/qix-engine-global/