### PR TITLE
Revert "Automated: Bump QIX Engine API docs (#146)"

### DIFF
--- a/docs/documentation/apis/qix-engine-definitions.md
+++ b/docs/documentation/apis/qix-engine-definitions.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # Definitions
 
-_QIX definitions for version 12.119.0._
+_QIX definitions for version 12.117.0._
 
 ## `AlfaNumString`
 
@@ -398,6 +398,7 @@ _No description._
 
 
 
+
 ## `ErrorData`
 
 _No description._
@@ -776,6 +777,14 @@ Defines the properties of a hypercube.<br>For more information about the definit
 | `qTitle` | [`StringExpr`](#stringexpr) | _No description._ |
 | `qCalcCondition` | [`NxCalcCond`](#nxcalccond) | _No description._ |
 | `qColumnOrder` | array | _No description._ |
+
+## `If`
+
+_No description._
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `qExpr` | string | _No description._ |
 
 ## `InteractDef`
 
@@ -2386,6 +2395,7 @@ _No description._
 | `qDisplayString` | string | Variable value. |
 | `qIsSystem` | boolean | Is set to true if the variable is a system variable. |
 | `qIsReserved` | boolean | Is set to true if the variable is a reserved variable. |
+
 
 ## `TreeData`
 

--- a/docs/documentation/apis/qix-engine-doc.md
+++ b/docs/documentation/apis/qix-engine-doc.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # Doc
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `AbortModal`
 

--- a/docs/documentation/apis/qix-engine-field.md
+++ b/docs/documentation/apis/qix-engine-field.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # Field
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `Clear`
 

--- a/docs/documentation/apis/qix-engine-genericbookmark.md
+++ b/docs/documentation/apis/qix-engine-genericbookmark.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # GenericBookmark
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `Apply`
 

--- a/docs/documentation/apis/qix-engine-genericdimension.md
+++ b/docs/documentation/apis/qix-engine-genericdimension.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # GenericDimension
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `ApplyPatches`
 

--- a/docs/documentation/apis/qix-engine-genericmeasure.md
+++ b/docs/documentation/apis/qix-engine-genericmeasure.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # GenericMeasure
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `ApplyPatches`
 

--- a/docs/documentation/apis/qix-engine-genericobject.md
+++ b/docs/documentation/apis/qix-engine-genericobject.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # GenericObject
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `AbortListObjectSearch`
 
@@ -488,7 +488,7 @@ Retrieves the values of a list object.<br>A data set is returned.
 
 ## `GetProperties`
 
-Returns the identifier, the type and the properties of the object.<br>Because it is not mandatory to set all properties when you define an object, the [`GetProperties`](#getproperties) method may show properties that were not set. In that case, default values are given.<br>If the object contains some soft properties, the soft properties are not returned by the [`GetProperties`](#getproperties) method. Use the [`GetEffectiveProperties`](#geteffectiveproperties) method instead.<br>If the object is linked to another object, the properties of the linking object are not returned by the [`GetProperties`](#getproperties) method. Use the [`GetEffectiveProperties`](#geteffectiveproperties) method instead.<br>The properties depends on the generic object type, see [properties](genericobject-layout.html).<br>If the member delta is set to true in the request object, only the delta is retrieved.
+Returns the identifier, the type and the properties of the object.<br>Because it is not mandatory to set all properties when you define an object, the [`GetProperties`](#getproperties) method may show properties that were not set. In that case, default values are given.<br>If the object contains some soft properties, the soft properties are not returned by the [`GetProperties`](#getproperties) method. Use the [`GetEffectiveProperties`](#geteffectiveproperties) method instead.<br>If the object is linked to another object, the properties of the linking object are not returned by the [`GetProperties`](#getproperties) method. Use the [`GetEffectiveProperties`](#geteffectiveproperties) method instead.<br>The properties depends on the generic object type, see [properties](generic-object-properties-render.html).<br>If the member delta is set to true in the request object, only the delta is retrieved.
 
 _No parameters._
 
@@ -821,7 +821,7 @@ _No return values._
 
 ## `SetProperties`
 
-Sets some properties for a generic object.<br>The properties depends on the generic object type, see [properties](genericobject-property.html).
+Sets some properties for a generic object.<br>The properties depends on the generic object type, see [properties](generic-object-properties-set.html).
 
 **Parameters:**
 

--- a/docs/documentation/apis/qix-engine-genericvariable.md
+++ b/docs/documentation/apis/qix-engine-genericvariable.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # GenericVariable
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `ApplyPatches`
 

--- a/docs/documentation/apis/qix-engine-global.md
+++ b/docs/documentation/apis/qix-engine-global.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # Global
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `AbortAll`
 
@@ -71,7 +71,7 @@ _No return values._
 
 ## `CopyApp`
 
-Copies an app that is in the Qlik Sense repository.<br>The engine copies the app into an app entity that was previously created by the repository. See the [Qlik Sense Repository Service API](
+Copies an app that is in the Qlik Sense repository.<br>The engine copies the app into an app entity that was previously created by the repository. See the [Qlik Sense Repository Service API](/Subsystems/RepositoryServiceAPI/Content/RepositoryServiceAPI/RepositoryServiceAPI-Introduction.htm) for more information.<br>This operation is possible only in Qlik Sense Enterprise.
 
 **Parameters:**
 

--- a/docs/documentation/apis/qix-engine-variable.md
+++ b/docs/documentation/apis/qix-engine-variable.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 # Variable
 
-_QIX methods for version 12.119.0._
+_QIX methods for version 12.117.0._
 
 ## `ForceContent`
 


### PR DESCRIPTION
The last engine api documentation contained broken links and bad formatting.

This reverts commit c127d1becbb7cca66fd0e104889efd2acb943596.