### PR TITLE
QIX Engine -> Qlik Associative Engine

### DIFF
--- a/docs/docs/downloads.md
+++ b/docs/docs/downloads.md
@@ -2,13 +2,13 @@
 
 ## Docker Images
 
-Qlik Core consists of a core set of services, including QIX Engine, that can be downloaded as Docker images:
+Qlik Core consists of a core set of services, including Qlik Associative Engine, that can be downloaded as Docker images:
 
 | Service    | Feature | Docker Image | Source Code |
 | ---------- | ------- | ------------ | ----------- |
-| [QIX Engine](./services/qix-engine/introduction.md) | The powerful associative indexing engine from Qlik and the foundation of Qlik Core | [qlikea/engine](https://hub.docker.com/r/qlikea/engine) | Closed source |
-| [License Service](./services/license-service.md) | Service required to run QIX Engine with a valid license | [qlikea/license-service](https://hub.docker.com/r/qlikea/license-service) | Closed source |
-| [Mira](./services/mira.md) | QIX Engine discovery service | [qlikea/mira](https://hub.docker.com/r/qlikea/mira) | [GitHub](https://github.com/qlik-ea/mira) |
+| [Qlik Associative Engine](./services/qix-engine/introduction.md) | The powerful associative indexing engine from Qlik and the foundation of Qlik Core | [qlikea/engine](https://hub.docker.com/r/qlikea/engine) | Closed source |
+| [License Service](./services/license-service.md) | Service required to run Qlik Associative Engine with a valid license | [qlikea/license-service](https://hub.docker.com/r/qlikea/license-service) | Closed source |
+| [Mira](./services/mira.md) | Qlik Associative Engine discovery service | [qlikea/mira](https://hub.docker.com/r/qlikea/mira) | [GitHub](https://github.com/qlik-ea/mira) |
 
 ## JavaScript Libraries
 
@@ -17,7 +17,7 @@ npm packages:
 
 | Library | Feature | Source Code |
 | ------- | ------- | ----------- |
-| [enigma.js](https://www.npmjs.com/package/enigma.js) | Communication with the QIX Engine | [GitHub](https://github.com/qlik-oss/enigma.js/) |
-| [halyard.js](https://www.npmjs.com/package/halyard.js) | Simplifies data loading into the QIX Engine | [GitHub](https://github.com/qlik-oss/halyard.js) |
+| [enigma.js](https://www.npmjs.com/package/enigma.js) | Communication with the Qlik Associative Engine | [GitHub](https://github.com/qlik-oss/enigma.js/) |
+| [halyard.js](https://www.npmjs.com/package/halyard.js) | Simplifies data loading into the Qlik Associative Engine | [GitHub](https://github.com/qlik-oss/halyard.js) |
 | [after-work.js](https://www.npmjs.com/package/after-work.js) | Unified testing framework for different test levels | [GitHub](https://github.com/qlik-oss/after-work.js) |
-| [picasso.js](https://www.npmjs.com/package/picasso.js) | Visualization library on top of the QIX Engine | [GitHub](https://github.com/qlik-oss/picasso.js/) |
+| [picasso.js](https://www.npmjs.com/package/picasso.js) | Visualization library on top of the Qlik Associative Engine | [GitHub](https://github.com/qlik-oss/picasso.js/) |

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-To get started with Qlik Core and QIX Engine, and learn the basic concepts,
+To get started with Qlik Core and Qlik Associative Engine, and learn the basic concepts,
 a number of examples and tutorials are provided.
 Here, a recommended path through the examples is provided that introduces different concepts step by step.
 
@@ -9,41 +9,43 @@ with source code that is available in separate open source repositories on GitHu
 
 ## Hello Qlik Core!
 
-Users new to Qlik products and QIX Engine should start here.
+Users new to Qlik products and Qlik Associative Engine should start here.
 
-The first set of examples introduce basic operations and usage of QIX Engine. Think of it as the "Hello World" of QIX
-Engine and the next steps after that. This is divided into three separate parts
+The first set of examples introduce basic operations and usage of Qlik Associative Engine. Think of
+it as the "Hello World" of the engine and the next steps after that. This is divided into three separate parts
 
-- [Hello Engine](./tutorials/hello-engine.md) - Running QIX Engine as a Docker container and using
+- [Hello Engine](./tutorials/hello-engine.md) - Running Qlik Associative Engine as a Docker container and using
     [enigma.js](https://github.com/qlik-oss/enigma.js/) to communicate with it
-- [Hello Data](./tutorials/hello-data.md) - Loading user data into QIX Engine using
+- [Hello Data](./tutorials/hello-data.md) - Loading user data into Qlik Associative Engine using
     [halyard.js](https://github.com/qlik-oss/halyard.js)
 - [Hello Visualization](./tutorials/hello-visualization.md) - Building a visualization using picasso.js
 
 ## Orchestration
 
-Users with previous knowledge about QIX Engine, its supporting libraries, and Qlik products, but that are new to
-container technologies such as Docker, will benefit from looking at:
+Users with previous knowledge about Qlik Associative Engine, its supporting libraries,
+and Qlik products, but that are new to container technologies such as Docker, will benefit
+from looking at:
 
 - [Orchestration](./tutorials/orchestration.md)
 
 This tutorial covers aspects such as:
 
-- Configuring and using a license for QIX Engine
-- Using QIX Engine in different container orchestration tools
-- Using Mira - the QIX Engine discovery service - when running multiple instances of QIX Engine in a cluster
+- Configuring and using a license for Qlik Associative Engine
+- Using Qlik Associative Engine in different container orchestration tools
+- Using Mira - the Qlik Associative Engine discovery service - when running multiple
+  instances of Qlik Associative Engine in a cluster
 
 ## In-Depth Tutorials
 
 The in-depth tutorials provide more detailed examples of how to work with more specific aspects of Qlik Core. These
 tutorials are; in recommended order to explore:
 
-- [Data Loading](./tutorials/data-loading.md) - Loading user data into QIX Engine
+- [Data Loading](./tutorials/data-loading.md) - Loading user data into Qlik Associative Engine
 - [Document Distribution](./tutorials/document-distribution.md) - Distributing updated documents/data
-    in a cluster of QIX Engine instances
+    in a cluster of Qlik Associative Engine instances
 - [Monitoring and Scaling](./tutorials/scalability/overview.md)
-    - Taking decisions on when to scale up or down the number of QIX Engine instances
-    - Placing and scheduling of QIX Engine sessions
+    - Taking decisions on when to scale up or down the number of Qlik Associative Engine instances
+    - Placing and scheduling of Qlik Associative Engine sessions
 - [Authorization](./tutorials/authorization.md)
-    - Using JWTs and JWT validation in QIX Engine
+    - Using JWTs and JWT validation in Qlik Associative Engine
     - Making sure users only see the data they are supposed to see

--- a/docs/docs/home.md
+++ b/docs/docs/home.md
@@ -3,11 +3,11 @@
 ## What is Qlik Core?
 
 Qlik Core provides a development platform for building custom data exploration and data
-visualization solutions on top of QIX Engine, the powerful associative indexing engine from Qlik.
+visualization solutions on top of Qlik Associative Engine, the powerful associative indexing engine from Qlik.
 
-QIX Engine differentiates from other vendors by dynamically calculating and providing associations based on data
-selections, without the need to rely on query-based analysis which restricts to linear exploration within a partial view
-of the data.
+Qlik Associative Engine differentiates from other vendors by dynamically calculating and providing associations
+based on data selections, without the need to rely on query-based analysis which restricts to linear exploration
+within a partial view of the data.
 
 ## Open Source
 
@@ -22,11 +22,11 @@ You can find us on [GitHub under the qlik-oss organization](https://github.com/q
 Qlik Core is designed to utilize the power of container-based solutions and microservice architectures, such as
 [Docker](https://docker.com).
 
-The QIX Engine on Linux, provided as a Docker image, forms the foundation of this.
+The Qlik Associative Engine on Linux, provided as a Docker image, forms the foundation of this.
 
 Developers building their solutions on Qlik Core are provided with a large range of powerful technologies, for example
-[Kubernetes](https://kubernetes.io), which enables container orchestration and elastic scaling of multiple QIX Engine
-instances in distributed environments.
+[Kubernetes](https://kubernetes.io), which enables container orchestration and elastic scaling of multiple Qlik
+Associative Engine instances in distributed environments.
 
 ## Live Demo
 

--- a/docs/docs/services/license-service.md
+++ b/docs/docs/services/license-service.md
@@ -1,10 +1,10 @@
 # License Service
 
-To run QIX Engine with a valid license, you are required to run the License Service.
-You should deploy the License Service together with the QIX Engine.
+To run Qlik Associative Engine with a valid license, you are required to run the License Service.
+You should deploy the License Service together with the Qlik Associative Engine.
 
 At start up, and periodically while it is running,
-each QIX Engine instance checks the License Service for a valid license.
+each Qlik Associative Engine instance checks the License Service for a valid license.
 
 !!! Note
     Since it is just a sidecar service, the License Service API is generally
@@ -19,8 +19,8 @@ It is developed by Qlik as closed source.
 ## Configuration
 
 You do not need to configure the License Service,
-but you do need to tell the [QIX Engine](./qix-engine/introduction.md) where to find it.
-You can do this by passing the following command line argument to the QIX Engine.
+but you do need to tell the [Qlik Associative Engine](./qix-engine/introduction.md) where to find it.
+You can do this by passing the following command line argument to the Qlik Associative Engine.
 
 ```sh
 -S LicenseServiceUrl=<License Service URL>
@@ -33,7 +33,7 @@ To see an example of a basic license configuration, see the [Orchestration](../t
 ## Deployment
 
 In most Qlik Core deployments, you will only need to deploy a single License Service instance.
-This is because traffic between QIX Engine instances and the License Service is low.
+This is because traffic between Qlik Associative Engine instances and the License Service is low.
 In cases where you need to consider load balancing or License Service availability,
 you can run multiple replicas of the License Service.
 

--- a/docs/docs/services/mira.md
+++ b/docs/docs/services/mira.md
@@ -1,9 +1,9 @@
 # Mira
 
-Mira is a QIX Engine discovery service for containerized environments.
-Mira finds the available QIX Engine instances and the properties of each instance.
+Mira is a Qlik Associative Engine discovery service for containerized environments.
+Mira finds the available Qlik Associative Engine instances and the properties of each instance.
 You can then use this information to make decisions about scalability and performance, for example,
-on which engine should you open a new session, or when will you need to start a new QIX Engine instance.
+on which engine should you open a new session, or when will you need to start a new Qlik Associative Engine instance.
 
 ## Distribution
 
@@ -29,33 +29,33 @@ The following environment variables can optionally be set:
 | ------------------------------------- | ----------------------- | ----------- |
 | MIRA_MODE                             | swarm                   | Operation mode of Mira.<br>- Can be `swarm`, `kubernetes`, `dns`, or `local`. |
 | MIRA_DISCOVERY_LABEL                  | qix-engine              | Label key that Mira uses to identify engine instances.<br/>- Applicable in modes `swarm`, `kubernetes`, and `local`. |
-| MIRA_DISCOVERY_HOSTNAME               | n/a                     | Hostname that Mira uses to query DNS for QIX Engine instances.<br>- Applicable in mode `dns`. |
+| MIRA_DISCOVERY_HOSTNAME               | n/a                     | Hostname that Mira uses to query DNS for Qlik Associative Engine instances.<br>- Applicable in mode `dns`. |
 | MIRA_ENGINE_API_PORT_LABEL            | qix-engine-api-port     | Label that Mira uses to determine the QIX API (websocket) port.<br/>- Applicable in modes `swarm`, `kubernetes`, and `local`. |
 | MIRA_ENGINE_METRICS_PORT_LABEL        | qix-engine-metrics-port | Label that Mira uses to determine the `/metrics` port.<br/>- Applicable in modes `swarm`, `kubernetes`, and `local`. |
-| MIRA_ENGINE_DISCOVERY_INTERVAL        | 10000                    | Interval in milliseconds for discovering QIX Engine instances. |
-| MIRA_ENGINE_UPDATE_INTERVAL           | 10000                    | Interval in milliseconds for updating health and metrics for QIX Engine instances. |
+| MIRA_ENGINE_DISCOVERY_INTERVAL        | 10000                    | Interval in milliseconds for discovering Qlik Associative Engine instances. |
+| MIRA_ENGINE_UPDATE_INTERVAL           | 10000                    | Interval in milliseconds for updating health and metrics for Qlik Associative Engine instances. |
 | MIRA_KUBERNETES_PROXY_PORT            | 8001                    | Port that Mira uses to communicate with the Kubernetes API server. |
 | MIRA_LOG_LEVEL                        | info                    | Minimum log level that Mira outputs when logging to `stdout`. |
 | MIRA_ALLOWED_RESPONSE_TIME            | 1000                    | Maximum allowed time in milliseconds from when a request is received until a response is being sent. |
 
 ### Operation Modes
 
-Mira supports different operation modes. The operation mode determines how Mira discovers QIX Engine instances.
+Mira supports different operation modes. The operation mode determines how Mira discovers Qlik Associative Engine instances.
 
 Mira supports the following operation modes:
 
 | Mode                                  | Description |
 | ------------------------------------- |  ----------- |
-|[Swarm](#swarm-mode)                   | Discovers QIX Engine instances in a Docker Swarm environment.            |
-|[Kubernetes](#kubernetes-mode)         | Discovers QIX Engine instances in a Kubernetes environment.              |
-|[DNS](#dns-mode)                       | Discovers QIX Engine instances using DNS service look-ups.               |
-|[Local](#local-mode)                   | Discovers QIX Engine instances running on the local Docker Engine.        |
+|[Swarm](#swarm-mode)                   | Discovers Qlik Associative Engine instances in a Docker Swarm environment.            |
+|[Kubernetes](#kubernetes-mode)         | Discovers Qlik Associative Engine instances in a Kubernetes environment.              |
+|[DNS](#dns-mode)                       | Discovers Qlik Associative Engine instances using DNS service look-ups.               |
+|[Local](#local-mode)                   | Discovers Qlik Associative Engine instances running on the local Docker Engine.        |
 
 To set the operation mode, define the environment variable `MIRA_MODE` on the Mira container.
 
-### QIX Engine Labeling
+### Qlik Associative Engine Labeling
 
-In all modes, except _DNS_ mode, Mira uses labels to identify QIX Engine instances.
+In all modes, except _DNS_ mode, Mira uses labels to identify Qlik Associative Engine instances.
 By default, the label that Mira searches for is `qix-engine`.
 You can change the label that Mira looks for by defining the `MIRA_DISCOVERY_LABEL`
 environment variable.
@@ -92,12 +92,12 @@ You can change the log level by setting the `MIRA_LOG_LEVEL` environment variabl
 ## Swarm Mode
 
 When Mira is running in _Swarm_ mode, it looks for a single Docker Swarm cluster that contains
-the QIX Engine instances running as Docker Swarm services.
+the Qlik Associative Engine instances running as Docker Swarm services.
 
 You can enable _Swarm_ mode by setting the environment variable `MIRA_MODE` to `swarm`
 before starting the Mira Docker service.
 
-In _Swarm_ mode Mira communicates with Docker Remote API to discover QIX Engine instances in the orchestration.
+In _Swarm_ mode Mira communicates with Docker Remote API to discover Qlik Associative Engine instances in the orchestration.
 How Mira should access the Docker Remote API can be configured in two ways.
 
 Mount `docker.sock` as a volume into the Mira container as shown in this [example](https://github.com/qlik-ea/mira/blob/master/docker-compose.yml).
@@ -123,12 +123,12 @@ services:
 
 The [docker-compose-swarm.yml](https://github.com/qlik-ea/mira/blob/master/examples/swarm/docker-compose-swarm.yml)
 file is an example of how Mira can be started in _Swarm_ mode
-with a QIX Engine instance that is labeled so that Mira will discover it.
+with a Qlik Associative Engine instance that is labeled so that Mira will discover it.
 
 A Docker Swarm cluster should already be created with at least one manager,
 and the Docker CLI client should be configured to issue commands towards the manager node.
 
-Run the following command to deploy Mira and QIX Engine in a stack named `mira-stack`:
+Run the following command to deploy Mira and Qlik Associative Engine in a stack named `mira-stack`:
 
 ```sh
 docker stack deploy -c docker-compose-swarm.yml mira-stack
@@ -170,7 +170,7 @@ services:
 ```
 
 In the example Docker stack file, the `qix-engine1` service contains the discovery label `qix-engine`.
-The service also contains two replicas, so Mira discovers two instances of the QIX Engine.
+The service also contains two replicas, so Mira discovers two instances of the Qlik Associative Engine.
 
 !!! Note
     The discovery label (`qix-engine`) must be set at the container (`qix-engine1`) level, not at the task (`deploy`) level.
@@ -180,7 +180,8 @@ The service also contains two replicas, so Mira discovers two instances of the Q
 
 ## Kubernetes Mode
 
-When Mira is running in _Kubernetes_ mode, Mira looks for QIX Engine instances running as pods in the Kubernetes cluster.
+When Mira is running in _Kubernetes_ mode, Mira looks for Qlik Associative Engine instances running
+as pods in the Kubernetes cluster.
 
 You can enable _Kubernetes_ mode by setting the environment variable `MIRA_MODE` to `kubernetes`
 before starting the Mira pod.
@@ -194,7 +195,7 @@ before starting the Mira pod.
 ### Example of Kubernetes Mode
 
 The [mira-deployment.yml](https://github.com/qlik-ea/mira/blob/master/examples/kubernetes/mira-deployment.yml) file
-is an example of how to deploy Mira and QIX Engine instances to Kubernetes.
+is an example of how to deploy Mira and Qlik Associative Engine instances to Kubernetes.
 
 A Kubernetes cluster should be set up and configured correctly.
 A quick way to do this, for experimental purposes, is to use
@@ -239,9 +240,9 @@ You can reach the Mira health check locally by running the following command.
 curl http://$(minikube ip):31000/v1/health
 ```
 
-#### Deploy QIX Engine Instances
+#### Deploy Qlik Associative Engine Instances
 
-For Mira to discover QIX Engine instances in the cluster, you can use a Kubernetes deployment file.
+For Mira to discover Qlik Associative Engine instances in the cluster, you can use a Kubernetes deployment file.
 Apply the example
 [engine-deployment.yml](https://github.com/qlik-ea/mira/blob/master/examples/kubernetes/engine-deployment.yml) file.
 
@@ -251,7 +252,7 @@ kubectl apply -f engine-deployment.yml
 
 This deployment file specifies two engine pod replicas.
 
-#### Expose QIX Engine Instances as Services
+#### Expose Qlik Associative Engine Instances as Services
 
 For Mira to be able to discover the engine instances,
 the engines must be exposed as services with named ports.
@@ -311,14 +312,14 @@ spec:
 ## DNS Mode
 
 When running Mira in _DNS_ mode, Mira resolves by hostname.
-Mira uses all returned IP addresses to fetch additional data on QIX Engine instances.
+Mira uses all returned IP addresses to fetch additional data on Qlik Associative Engine instances.
 
 You can enable _DNS_ mode by setting the environment variable `MIRA_MODE` to `dns`.
 
 ### Hostname Configuration
 
-When Mira is running in _DNS_ mode, Mira does not look for discovery labels to find QIX Engine instances.
-Instead, Mira uses the hostname that is used to resolve QIX Engine instances.
+When Mira is running in _DNS_ mode, Mira does not look for discovery labels to find Qlik Associative Engine instances.
+Instead, Mira uses the hostname that is used to resolve Qlik Associative Engine instances.
 You can set the hostname in the `MIRA_DISCOVERY_HOSTNAME` environment variable.
 
 ### Example of DNS Mode
@@ -328,7 +329,7 @@ is an example of how to configure DNS mode in a Docker Swarm environment.
 
 !!! Note
     By default, Docker Swarm assigns DNS names to services. The environment variables that set _DNS_ mode and
-    the QIX Engine instance hostname correspond to the service named `qix-engine`.
+    the Qlik Associative Engine instance hostname correspond to the service named `qix-engine`.
 
 ```yml
 services:
@@ -345,7 +346,7 @@ services:
 
 ## Local Mode
 
-When Mira is running in _Local_ mode, Mira looks for QIX Engine instances
+When Mira is running in _Local_ mode, Mira looks for Qlik Associative Engine instances
 that are running on the `localhost` Docker Engine, without any orchestration platform such as Docker Swarm or Kubernetes.
 
 You can enable _Local_ mode by setting the `MIRA_MODE` environment variable to `local`
@@ -362,7 +363,7 @@ With the `docker-compose.yml` file in the current working directory, run the fol
 docker-compose up -d
 ```
 
-To verify that Mira discovers the two QIX Engine containers, run the following command.
+To verify that Mira discovers the two Qlik Associative Engine containers, run the following command.
 
 ```sh
 curl http://localhost:9100/v1/engines

--- a/docs/docs/services/qix-engine/access-control.md
+++ b/docs/docs/services/qix-engine/access-control.md
@@ -5,14 +5,14 @@
     since this feature may change in the future.
 
 Being able to control which users can do what in the context
-of a document is often necessary. In QIX Engine we support
+of a document is often necessary. In Qlik Associative Engine we support
 [Attribute-Based Access Control (ABAC)](https://en.wikipedia.org/wiki/Attribute-based_access_control)
 which lets you control the document resources based on a users'
 attributes rather than using roles or other, more static, means.
 
 ## Configuration
 
-Rules are defined, one on each row, in text files. QIX Engine will
+Rules are defined, one on each row, in text files. Qlik Associative Engine will
 apply rules in order (except for deny rules which are always applied first,
 regardless of where they are defined).
 
@@ -33,7 +33,7 @@ docker run
 
 ## Allow versus Deny
 
-In addition to using _Allow_ rules to grant access, the QIX Engine
+In addition to using _Allow_ rules to grant access, the Qlik Associative Engine
 also supports _Deny_ rules to deny access.
 
 !!! Note

--- a/docs/docs/services/qix-engine/apis/data-loading/data-loading.md
+++ b/docs/docs/services/qix-engine/apis/data-loading/data-loading.md
@@ -5,27 +5,27 @@
     since this feature may change in the future.
 
 Typically, a connector is implemented as a stateless Docker container that
-sits between the QIX Engine and the data source, as shown below.
+sits between the Qlik Associative Engine and the data source, as shown below.
 
 ``` asciiart
 +-------------+              +-------------+                +-------------+
-| QIX Engine  | --GetData--> |  Connector  | -------------> | Data Source |
+| Qlik Associative Engine  | --GetData--> |  Connector  | -------------> | Data Source |
 |             | <----------  |             | <------------  |             |
 +-------------+              +-------------+                +-------------+
 ```
 
-The QIX Engine communicates with the data source through the
+The Qlik Associative Engine communicates with the data source through the
 [Data Connector gRPC API](data-connector-grpc.proto).
 The data connector fetches data from the source and sends it to the engine
 in a consumable format.
 
 !!! Tip
-    The simplest way for the QIX Engine to discover
+    The simplest way for the Qlik Associative Engine to discover
     available connectors is to use the GrpcConnectorPlugins.
 
 ## GetData Function
 
-When loading data, the QIX Engine sends one gRPC `GetData` call per table,
+When loading data, the Qlik Associative Engine sends one gRPC `GetData` call per table,
 and the server returns a stream of data chunks.
 
 ``` proto
@@ -57,7 +57,7 @@ For example, the input structure might look like this:
 The `GetData` call returns a stream of data chunks.
 
 The connector sends data from the data source to the
-QIX Engine, translating the data piece by piece.
+Qlik Associative Engine, translating the data piece by piece.
 The connector also supplies a gRPC header `x-qlik-getdata-bin` that contains metadata.
 
 ### Data Chunks

--- a/docs/docs/services/qix-engine/doc-synchronization.md
+++ b/docs/docs/services/qix-engine/doc-synchronization.md
@@ -6,18 +6,19 @@
 
 ## Description
 
-For sharing documents between multiple instances the QIX Engine uses a message broker called [RabbitMQ](https://www.rabbitmq.com/).
-With this feature the QIX Engine instances running in a cluster, regardless of orchestration,
+For sharing documents between multiple instances the Qlik Associative Engine uses a message broker called [RabbitMQ](https://www.rabbitmq.com/).
+With this feature the Qlik Associative Engine instances running in a cluster, regardless of orchestration,
 will assume that the cluster uses a shared persistence layer.
 What type of shared persistence volume that should be used is configurable by the end-user,
 as long as the volume is based on a block file system.
-The QIX Engines subscribes and publishes events to the message broker which propagates change events to other instances.
+The Qlik Associative Engines subscribes and publishes events to the message broker which propagates change
+events to other instances.
 
 ## Configuration
 
-To configure a QIX Engine to use a `RabbitMQ` broker you will need to pass additional startup parameters.
+To configure a Qlik Associative Engine to use a `RabbitMQ` broker you will need to pass additional startup parameters.
 As shown in the example below this configuration is also dependent on `ABAC` being enabled and a set of rules are defined.
-Further information regarding access control in QIX Engine can be found [here](access-control.md).
+Further information regarding access control in Qlik Associative Engine can be found [here](access-control.md).
 
 ```bash
 docker run
@@ -34,16 +35,16 @@ docker run
     -S UseEventBus=1
 ```
 
-If this feature is enabled the QIX Engine will assume that there is a `RabbitMQ` message broker
+If this feature is enabled the Qlik Associative Engine will assume that there is a `RabbitMQ` message broker
 available on the address specified by the `RabbitHost` parameter.
 
 In the configuration example above we are mounting a folder `-v <host document folder>:<container document folder>`,
 which is also passed in as `DocumentDirectory`.
-This is the folder which the QIX Engine container will use for storing documents,
-and the mounted folder can then be shared with other QIX Engine instances.
+This is the folder which the Qlik Associative Engine container will use for storing documents,
+and the mounted folder can then be shared with other Qlik Associative Engine instances.
 
 ## Example
 
-To show how two QIX Engine instances are sharing the same document using the message broker,
+To show how two Qlik Associative Engine instances are sharing the same document using the message broker,
 we have implemented a basic example in `Kubernetes` using `Persisted Volumes`.
 You can find the example [here](https://github.com/qlik-ea/example-doc-sync).

--- a/docs/docs/services/qix-engine/introduction.md
+++ b/docs/docs/services/qix-engine/introduction.md
@@ -1,19 +1,19 @@
-# QIX Engine
+# Qlik Associative Engine
 
-The QIX Engine is the central service in the Qlik Core stack. It has a lot of features and configuration options
+The Qlik Associative Engine is the central service in the Qlik Core stack. It has a lot of features and configuration options
 which we have dedicated pages for. Please use the menu on your left to read more about the unique capabilities
-of QIX Engine, and check out our tutorials how to configure your instances of QIX Engine.
+of Qlik Associative Engine, and check out our tutorials how to configure your instances of Qlik Associative Engine.
 
 ## Distribution
 
-QIX Engine is distributed as a Docker image and is available on Docker Hub as
+Qlik Associative Engine is distributed as a Docker image and is available on Docker Hub as
 [qlikea/engine](https://hub.docker.com/r/qlikea/engine).
 
-The QIX Engine is developed by Qlik as closed source.
+The Qlik Associative Engine is developed by Qlik as closed source.
 
 ## API
 
-QIX Engine supports multiple APIs, designed for specific use cases.
+Qlik Associative Engine supports multiple APIs, designed for specific use cases.
 
 API | Description
 --- | -----------
@@ -22,12 +22,12 @@ API | Description
 
 ## Metrics
 
-Following the [Metrics](../../conventions/metrics.md) conventions, QIX Engine exposes
+Following the [Metrics](../../conventions/metrics.md) conventions, Qlik Associative Engine exposes
 metrics that can be used to monitor the service.
 
-QIX Engine exposes the metrics data on a separate port from its other APIs, this separation
+Qlik Associative Engine exposes the metrics data on a separate port from its other APIs, this separation
 was made to ensure that exposing the default API (port 9076) wouldn't also expose potentially
 sensitive data from the metrics endpoint.
 
 The metrics endpoint can be found on port 9090 by default (example: `http://localhost:9090/metrics`),
-you may configure this by starting QIX Engine with `-S PrometheusPort <port number>`.
+you may configure this by starting Qlik Associative Engine with `-S PrometheusPort <port number>`.

--- a/docs/docs/services/qix-engine/logging.md
+++ b/docs/docs/services/qix-engine/logging.md
@@ -1,10 +1,11 @@
 # Logging
 
-The QIX Engine follows the logging format and levels that are specified in the [logging](../../conventions/logging.md) conventions.
+The Qlik Associative Engine follows the logging format and levels that are specified in the
+[logging](../../conventions/logging.md) conventions.
 
 ## Log Types
 
-Depending on the category of the log event, the QIX Engine uses different log types, and each
+Depending on the category of the log event, the Qlik Associative Engine uses different log types, and each
 log type can have an individual log verbosity, as described in [Log Levels](#log-levels) section.
 You can also toggle log types depending on scenario.
 
@@ -16,7 +17,7 @@ The following table lists the log types that are available and the default verbo
 | Performance | Performance log, typically containing metrics, for example, NbrActiveUsers and CPULoad. | PerformanceLogVerbosity | 4 |
 | Audit | User based detailed logging. </br> For example, when the user makes a selection in a document. | AuditLogVerbosity | 0 |
 | Session |  Information about a client session, for example, user, machine ID, ip-address, port. | SessionLogVerbosity | 4 |
-| Traffic | JSON traffic to and from the QIX Engine. | TrafficLogVerbosity | 0 |
+| Traffic | JSON traffic to and from the Qlik Associative Engine. | TrafficLogVerbosity | 0 |
 | QixPerformance | QIX protocol performance. | QixPerformanceLogVerbosity | 0 |
 | SmartSearchQuery | Smart Search query log. | SmartSearchQueryLogVerbosity | 3 |
 | SmartSearchIndex | Smart Search index log. | SmartSearchIndexLogVerbosity | 3 |
@@ -27,7 +28,7 @@ The following table lists the log types that are available and the default verbo
 When you start the docker container, you configure the log type and the log level by setting the command line parameter.
 
 !!! Note
-    While the QIX Engine follows the [Logging](../../conventions/logging.md#logging-levels) conventions,
+    While the Qlik Associative Engine follows the [Logging](../../conventions/logging.md#logging-levels) conventions,
     each log level is also mapped to a numeric value that is used to set the logging verbosity level.
 
 | Log level | Value |
@@ -56,7 +57,7 @@ services:
 ## Log Format
 
 In addition to the required fields that are listed in the [Logging](../../conventions/logging.md) conventions,
-the QIX Engine also has a few log fields that are common to all log types:
+the Qlik Associative Engine also has a few log fields that are common to all log types:
 
 | Field | Description |
 | ----- | ----------- |
@@ -79,7 +80,7 @@ These fields are listed in the tables that follow.
 
 | Field | Description |
 | ----- | ----------- |
-| version | The QIX Engine component version. |
+| version | The Qlik Associative Engine component version. |
 | entry_type | The state (Server Starting, Normal). |
 | active_doc_sessions | Number of active engine sessions. A session is active when a user is currently performing some action on an document, for example, when making selections or creating content. |
 | doc_sessions | Number of idle sessions waiting for termination. |

--- a/docs/docs/services/qix-engine/resource-management.md
+++ b/docs/docs/services/qix-engine/resource-management.md
@@ -3,7 +3,7 @@
 ## Memory/RAM
 
 The main memory RAM is the primary
-storage for all data to be analyzed by the QIX Engine. The engine mainly
+storage for all data to be analyzed by the Qlik Associative Engine. The engine mainly
 allocates memory for:
 
 * The unaggregated dataset that is defined by the document data model.
@@ -12,10 +12,10 @@ allocates memory for:
 * The session state for each user of the document.
 * Temporary allocations for helper tables used during calculations.
 
-When a user requests a document, the QIX Engine loads it into memory (if it has not already been loaded).
+When a user requests a document, the Qlik Associative Engine loads it into memory (if it has not already been loaded).
 The dataset for a document is only loaded once, regardless of the number of concurrent users.
 
-When a user makes a selection in the document, the QIX Engine
+When a user makes a selection in the document, the Qlik Associative Engine
 performs real-time calculations for that selection.
 Newly calculated results are added to the in-memory
 cache, which is shared with all users. User session states are also stored
@@ -24,25 +24,25 @@ the same state.
 
 ### Controlling the allocation of memory
 
-There are two fundamental settings for controlling how the QIX Engine
+There are two fundamental settings for controlling how the Qlik Associative Engine
 allocates and releases memory:
 
 * Working set Low / Min memory usage:
 
-    This setting defines the amount of memory that the QIX Engine will use.
-    If memory allocation remains at or below this level, the QIX Engine will not
+    This setting defines the amount of memory that the Qlik Associative Engine will use.
+    If memory allocation remains at or below this level, the Qlik Associative Engine will not
     attempt to minimize memory allocation.
     For example, if the physical RAM on your server is 256 GB and _Working set Low / Min memory
-    usage_ is set to 70%, the QIX Engine will not try to minimize its memory
+    usage_ is set to 70%, the Qlik Associative Engine will not try to minimize its memory
     allocation until it uses 179.2 GB of RAM.
     After passing this point, the engine uses compression algorithms to minimize memory consumption.
     However, it will not use any memory if it is not used for a beneficial purpose.
 
 * Working set High / Max memory usage:
 
-    This setting defines the point above which the QIX Engine cannot allocate any memory.
+    This setting defines the point above which the Qlik Associative Engine cannot allocate any memory.
     For example, if the physical RAM on your server is 256
-    GB and _Working set High / Max memory usage_ is set to 90%, the QIX Engine
+    GB and _Working set High / Max memory usage_ is set to 90%, the Qlik Associative Engine
     cannot allocate any RAM above 230.4 GB.
 
 !!! Note
@@ -53,11 +53,11 @@ allocates and releases memory:
 We recommend that you leave these settings with their default values.
 However, on servers with large RAM (256 GB and upwards), the settings can
 be changed to allocate a couple of GBs of RAM for the operating system, and
-to allow the remaining RAM to be used by the QIX Engine.
+to allow the remaining RAM to be used by the Qlik Associative Engine.
 
-#### When QIX Engine starts
+#### When Qlik Associative Engine starts
 
-The operating system allocates RAM for the QIX Engine to use.
+The operating system allocates RAM for the Qlik Associative Engine to use.
 When the engine starts, it reserves RAM based on the
 _Working set Low / Min memory usage_ setting. The engine allocates all of its RAM to
 cache result sets. When it reaches the RAM limit, it begins purging cached result sets to make
@@ -65,15 +65,15 @@ room for new documents, calculated aggregates, and session state information.
 This means that an environment can operate on the boundary of the
 _Working set Low / Min memory usage_ setting without impacting the user-perceived
 performance, as long as there are old result sets that can be purged.
-The QIX Engine prioritizes which cached result sets to purge based on their age, size,
+The Qlik Associative Engine prioritizes which cached result sets to purge based on their age, size,
 and time of calculation.
 
 #### When RAM is scarce
 
 If the RAM becomes scarce, the operating system might
-perform paging. This which means that some of the QIX Engine memory is swapped
+perform paging. This which means that some of the Qlik Associative Engine memory is swapped
 from physical RAM to virtual memory (secondary storage). If the
-QIX Engine is allocated to virtual memory, it may become orders of magnitude slower
+Qlik Associative Engine is allocated to virtual memory, it may become orders of magnitude slower
 than when using physical RAM. This is undesirable and may lead to a poor user
 experience. There is no guarantee that paging will not
 occur between the _Working set Low / Min memory usage_ setting and the
@@ -81,12 +81,12 @@ _Working set High / Max memory usage_ setting, but above the
 _Working set High / Max memory usage_ setting, paging will definitively occur.
 
 !!! Note
-    Paging is not unique to the QIX Engine, as the RAM is handled
+    Paging is not unique to the Qlik Associative Engine, as the RAM is handled
     by the operating system.
 
 ### Example: Allocation of memory when loading a single document
 
-The following figure shows an example of the memory allocation over time, with the QIX Engine
+The following figure shows an example of the memory allocation over time, with the Qlik Associative Engine
 running on a clean server and users interacting with a document.
 
 ![Single doc allocation](../../../images/qix-service/qix_allocation_single_doc.png)
@@ -97,7 +97,7 @@ the result sets are cached and stored in RAM. This takes up the largest chunk of
 cached result set can be served without any additional calculation, so they are quite useful.
 A small amount of memory is allocated to keeping track of the state of active user sessions.
 
-The QIX Engine does not allow persistent allocation of more memory than what is specified
+The Qlik Associative Engine does not allow persistent allocation of more memory than what is specified
 by the _Working set Low / Min memory usage_ setting. When the total amount of
 allocated RAM goes beyond that setting, previously cached result sets are
 purged to make room for new ones. When the document is unloaded from memory,
@@ -106,7 +106,7 @@ allocated by the document.
 The cached result sets stay in memory if there are no other requests to use allocated memory,
 since these can be useful later on.
 
-A QIX Engine session is considered to be _dropped_ once the session has no more connected
+A Qlik Associative Engine session is considered to be _dropped_ once the session has no more connected
 WebSockets, and the session time to live (TTL) has lapsed (TTL is by default 0).
 
 ### Example: Allocation of memory when loading multiple documents
@@ -116,14 +116,14 @@ when the total amount of allocated memory touches the _Working set Low /Min memo
 
 ![Multiple doc allocation](../../../images/qix-service/qix_allocation_multiple_docs.png)
 
-To release memory to load new documents, the QIX Engine purges cached result sets.
+To release memory to load new documents, the Qlik Associative Engine purges cached result sets.
 The amount of RAM that is used to cache result sets is the floating amount between
 the _Working set Low / Min memory usage_ setting and the amount that is consumed by
 the documents and session state information.
 
 ### Investigating memory usage
 
-It is good practice to minitor how the QIX Engine uses memory with your data
+It is good practice to minitor how the Qlik Associative Engine uses memory with your data
 models and documents.
 
 ![Monitoring RAM](../../../images/qix-service/monitoring_ram.png)
@@ -135,8 +135,8 @@ which is worth investigating as it often results in a slow response time.
 
 ### Summary of memory management
 
-* The QIX Engine caches all result sets as long as there is available RAM.
-* The QIX Engine releases memory only when unloading documents. When a document
+* The Qlik Associative Engine caches all result sets as long as there is available RAM.
+* The Qlik Associative Engine releases memory only when unloading documents. When a document
     is unloaded from memory, the total amount of allocated memory drops by the
     same amount as originally allocated by the document.
 * Cached result sets stay in memory unless there are new requests that need allocated memory.
@@ -144,14 +144,14 @@ which is worth investigating as it often results in a slow response time.
     and cached results are purged to make room for new values.
 * The age, size, and time of calculation are factors in the prioritization
     of the values to purge.
-* The QIX Engine purges old sessions when the "maximum inactive session time"
+* The Qlik Associative Engine purges old sessions when the "maximum inactive session time"
     value is reached.
 * High memory usage is usually the result of many cached results.
 * As long as paging does not occur, high memory usage is a good thing.
 
 ## CPU
 
-The QIX Engine leverages the processor to dynamically create aggregations as
+The Qlik Associative Engine leverages the processor to dynamically create aggregations as
 needed in real time, which results in a fast, flexible, and intuitive user
 experience.
 
@@ -161,7 +161,7 @@ for a document. When the user interface requires aggregates, for example,
 to display a chart object or to recalculate after a selection has been made,
 the aggregation is done in real time, and this requires CPU processing power.
 
-The QIX Engine is multi-threaded and optimized to take advantage of multiple
+The Qlik Associative Engine is multi-threaded and optimized to take advantage of multiple
 processor cores. All available cores are used almost linearly when calculating
 charts. During calculations, the engine makes a short burst of intense CPU
 usage in real time.
@@ -176,7 +176,7 @@ requires a certain amount of processing capacity
 and a peak of high utilization results in faster response
 times as all available cores can cooperate to complete the calculation.
 
-The QIX Engine has a central cache function, which means that chart calculations only
+The Qlik Associative Engine has a central cache function, which means that chart calculations only
 need to be done once, which results in better user experience, faster
 response times, and lower CPU utilization.
 
@@ -187,7 +187,7 @@ performance.
 
 ![CPU Average High](../../../images/qix-service/cpu_high_average.png)
 
-The are cases where the QIX Engine does not scale well over cores:
+The are cases where the Qlik Associative Engine does not scale well over cores:
 
 * A single user triggers single-threaded operations.
 * The underlying hardware does not allow for good scaling, for example, when
@@ -195,18 +195,18 @@ The are cases where the QIX Engine does not scale well over cores:
 
 ### Summary of CPU utilization and scaling over cores
 
-* Peaks with 100% CPU utilization are good because they indicate that the QIX Engine
+* Peaks with 100% CPU utilization are good because they indicate that the Qlik Associative Engine
     is using all available capacity to deliver the responses as fast as possible.
 * High average CPU utilization (>70%) is bad as it means that the system
     saturates and incoming selections in documents have to be queued prior to
     being served.
-* The QIX Engine processing capacity can be increased by adding more cores or by
+* The Qlik Associative Engine processing capacity can be increased by adding more cores or by
     increasing the clock frequency. More processing capacity makes the Engine
     handle load peaks in a robust manner.
 
 ## Linear scaling of resources
 
-The QIX Engine consumes approximately the same amount of resources
+The Qlik Associative Engine consumes approximately the same amount of resources
 whether documents are loaded and accessed in parallel or in sequence
 on a specific server. Also, as long as the CPU does not become saturated, the throughput is similar
 regardless of whether the documents are loaded in parallel or in sequence.
@@ -234,12 +234,12 @@ You should monitor the following two log warnings:
 
 * **WorkingSet: Virtual Memory is growing beyond parameters…**
 
-    The QIX Engine experiences problems staying below the
+    The Qlik Associative Engine experiences problems staying below the
     _Working set Low / Min memory usage_ setting.
 
 * **WorkingSet: Virtual Memory is growing CRITICALLY beyond parameters…**
 
-    The QIX Engine has not managed to get back below the _Working set Low / Min memory usage_ setting
+    The Qlik Associative Engine has not managed to get back below the _Working set Low / Min memory usage_ setting
     and paging is or is about to happen.
 
 The first warning is not a problem if this happens every now and then, but depending on the
@@ -284,7 +284,7 @@ a trend like this, you should investigate why this is happening to avoid future 
 
 ## Scaling up versus scaling out
 
-There are two ways in which you can scale a QIX Engine deployment to match a static or dynamic workload:
+There are two ways in which you can scale a Qlik Associative Engine deployment to match a static or dynamic workload:
 
 * **Horizontally**
 
@@ -294,7 +294,7 @@ There are two ways in which you can scale a QIX Engine deployment to match a sta
 
     Add more resources to current nodes/hosts.
 
-Both of these options work well with the QIX Engine as it is predictable
+Both of these options work well with the Qlik Associative Engine as it is predictable
 and it scales linearly to the load.
 
 If users and their respective documents work well on the current

--- a/docs/docs/tutorials/authorization.md
+++ b/docs/docs/tutorials/authorization.md
@@ -1,6 +1,6 @@
 # Authorization
 
-In this tutorial, you will learn how to configure JSON Web Tokens (JWT) and the QIX Engine
+In this tutorial, you will learn how to configure JSON Web Tokens (JWT) and the Qlik Associative Engine
 to manage and authenticate users.
 
 ## JSON Web Token
@@ -8,7 +8,7 @@ to manage and authenticate users.
 JWT is an open standard for creating access tokens. To learn more about JWT,
 see the [JWT documentation](https://jwt.io/) and the [JWT Standard](https://tools.ietf.org/html/rfc7519).
 
-The QIX Engine uses JWTs for the following tasks:
+The Qlik Associative Engine uses JWTs for the following tasks:
 
 - Ensuring that only authenticated users are allowed to connect.
 - Connecting users to the same sessions.
@@ -39,7 +39,7 @@ and the hashing algorithm that is used to sign the token. For example:
 #### Payload
 
 The payload contains the claims of the JWT.
-The relevant claims that are evaluated by the QIX Engine are the subject and the expiration date.
+The relevant claims that are evaluated by the Qlik Associative Engine are the subject and the expiration date.
 
 | Field | Description |
 | -----|------------|
@@ -58,7 +58,7 @@ For example:
 #### Signature
 
 The signature is used to verify the authenticity of the token.
-The QIX Engine supports the following JWT signing algorithms:
+The Qlik Associative Engine supports the following JWT signing algorithms:
 
 | Encryption type | Algorithms |
 | ----            | --------- |
@@ -68,9 +68,9 @@ The QIX Engine supports the following JWT signing algorithms:
 
 To learn more about JWT signatures, see [Signature](https://jwt.io/introduction/#signature).
 
-### QIX Engine configuration
+### Qlik Associative Engine configuration
 
-To validate JWTs, you must configure the QIX Engine by specifying
+To validate JWTs, you must configure the Qlik Associative Engine by specifying
 the JWT enforcement type and the JWT secret in the `docker-compose.yml` file.
 
 The enforcement type is defined as:
@@ -108,7 +108,7 @@ services:
 
 ### Validation
 
-The JWT is passed to the QIX Engine in the `Authorization` header using
+The JWT is passed to the Qlik Associative Engine in the `Authorization` header using
 the `Bearer` schema, and is validated once the websocket connection is established.
 
 `Authorization: Bearer <token>`
@@ -130,7 +130,7 @@ To learn more about section access, see [Managing security with section access](
 ### Managing access control
 
 Access control is managed through one or several security tables loaded
-in the same way that the QIX Engine normally loads data.
+in the same way that the Qlik Associative Engine normally loads data.
 
 In the example below, the load script grants regional
 users access to their respective country data
@@ -162,7 +162,7 @@ DE, Other, 303
 ];
 ```
 
-The QIX Engine maps the `sub` field from the JWT to the user names
+The Qlik Associative Engine maps the `sub` field from the JWT to the user names
 that are specified in the section access table.
 In the example above, the section access table is linked to the `Sales` table
 through the `COUNTRY` field value,

--- a/docs/docs/tutorials/data-loading.md
+++ b/docs/docs/tutorials/data-loading.md
@@ -24,7 +24,7 @@ like Dropbox, OneDrive, and GoogleDrive.
 
 The data connection service that is used in this tutorial
 works by defining a unique HTTP endpoint for each registered connection provider.
-The QIX Engine can then access different data sources by making calls
+The Qlik Associative Engine can then access different data sources by making calls
 to the service-defined HTTP endpoints.
 
 Before you start this example, you must clone the
@@ -74,7 +74,7 @@ and loading data from these data sources is supported by the
 ## Loading data from a PostgreSQL database using gRPC protocol
 
 In this example workflow, load data from a PostgreSQL database
-using the gRPC protocol in the QIX Engine.
+using the gRPC protocol in the Qlik Associative Engine.
 
 Before you start this example, you must clone the [postgres-grpc-connector](https://github.com/qlik-ea/postgres-grpc-connector)
 Git repository to your local machine.
@@ -108,11 +108,11 @@ Do the following:
 
     - A database
     - A postgres-grpc-connector
-    - The QIX Engine
+    - The Qlik Associative Engine
 
     **Note:** If you look at the `docker-compose.yml` file, port `9076` on the container
     is mapped to port `19076` on the local machine.
-    This lets you access the QIX Engine from outside of the Docker network.
+    This lets you access the Qlik Associative Engine from outside of the Docker network.
     In this example, we want to trigger a load of the airport data
     from outside of the container.
 
@@ -120,12 +120,12 @@ Do the following:
 
     - `-S EnableGrpcCustomConnectors=1`
 
-        Enables gRPC connectors in the QIX Engine.
+        Enables gRPC connectors in the Qlik Associative Engine.
 
     - `-S GrpcConnectorPlugins="postgres-grpc-connector,postgres-grpc-connector:50051"`
 
         Creates a connector of the type `postgres-grpc-connector`,
-        which we tell the QIX Engine exists on host `postgres-grpc-connector`
+        which we tell the Qlik Associative Engine exists on host `postgres-grpc-connector`
         and listening on port `50051`.
 
 1. Verify that the three services are running in containers.
@@ -138,22 +138,22 @@ Do the following:
     The `postgres-grpc-connector` can therefore access the database container on this port.
 
     The `postgres-grpc-connector` container exposes port `50051`.
-    This is the port that we told the QIX Engine to talk to
+    This is the port that we told the Qlik Associative Engine to talk to
     with the commands in the `docker-compose.yml` file.
 
-    The QIX Engine exposes ports `9076` and `9090`.
+    The Qlik Associative Engine exposes ports `9076` and `9090`.
     Port `9090` is used for metrics, which is not relevant for this example.
-    Port `9076` is the standard QIX Engine API port. Since we mapped it to
+    Port `9076` is the standard Qlik Associative Engine API port. Since we mapped it to
     port `19076` on your local machine, _outside_ of the container,
-    requests to your machine on port `19076` will go to QIX Engine container.
+    requests to your machine on port `19076` will go to Qlik Associative Engine container.
 
 1. Trigger the data load.
 
     Now that we have a populated database, a gRPC connector container,
-    and a QIX Engine running, all we need is to trigger a load of the data.
+    and a Qlik Associative Engine running, all we need is to trigger a load of the data.
 
     For this example, a small Node.js program that uses the Qlik library [enigma.js](https://github.com/qlik-oss/enigma.js)
-    that talks to the QIX Engine triggers a load of the airport data with the gRPC connector.
+    that talks to the Qlik Associative Engine triggers a load of the airport data with the gRPC connector.
 
     ```bash
     cd reload-runner
@@ -166,12 +166,12 @@ Do the following:
 ## What is happening
 
 Once the containers are running and you trigger the data load,
-the program creates and opens an app called `reloadapp.qvf` on the QIX Engine.
+the program creates and opens an app called `reloadapp.qvf` on the Qlik Associative Engine.
 Then it creates a connection of the type we defined earlier.
 
 ```js
 app.createConnection({
-  qType: 'postgres-grpc-connector', //the name we defined as a parameter to the QIX Engine in our docker-compose.yml
+  qType: 'postgres-grpc-connector', //the name we defined as a parameter to the Qlik Associative Engine in our docker-compose.yml
   qName: 'postgresgrpc',
   //the connection string inclues both the provider to use and parameters to it.
   qConnectionString: 'CUSTOM CONNECT TO "provider=postgres-grpc-connector;host=postgres-database;port=5432;database=postgres"',
@@ -182,7 +182,7 @@ app.createConnection({
 
 The connection string
 `CUSTOM CONNECT TO "provider=postgres-grpc-connector;host=postgres-database;port=5432;database=postgres`
-tells the QIX Engine to use the newly created connection.
+tells the Qlik Associative Engine to use the newly created connection.
 The remaining part of the connection string specifies parameters to the gRPC connector,
 such as the database host, address, and port.
 You can see that the host is the name of the service we defined in the `docker-compose.yml` file
@@ -201,9 +201,9 @@ app.setScript(script);
 
 We use the name `postgresgrpc`, which we defined when we created our connection.
 Then, we load the airport data from the PostgreSQL `airports` table into
-a QIX Engine table that is named `Airports`.
+a Qlik Associative Engine table that is named `Airports`.
 
-Next, we reload the data to load the new data into the QIX Engine. Finally, we
+Next, we reload the data to load the new data into the Qlik Associative Engine. Finally, we
 fetch the first 10 results of the `Airports` table and print them to the console.
 
 **Tip:** We recommend that you take a look inside the `index.js` file

--- a/docs/docs/tutorials/hello-data.md
+++ b/docs/docs/tutorials/hello-data.md
@@ -1,6 +1,6 @@
 # Hello Data
 
-Load data into and retrieve data from the QIX Engine running in a Docker container.
+Load data into and retrieve data from the Qlik Associative Engine running in a Docker container.
 
 ## Prerequisites
 
@@ -12,15 +12,15 @@ and all commands should be executed from this Git repository.
 You must have [Node.js](https://nodejs.org/en/) and npm
 installed on your local machine.
 
-**Note:** Make sure the QIX Engine is running. Run `docker-compose up -d`
+**Note:** Make sure the Qlik Associative Engine is running. Run `docker-compose up -d`
 command in a command shell to start the engine in a Docker container.
-If you are unfamiliar with starting the QIX Engine in a Docker container, we
+If you are unfamiliar with starting the Qlik Associative Engine in a Docker container, we
 recommend that you begin with the [Hello Engine](./hello-engine.md) tutorial.
 
 ## Loading and retrieving data
 
 To load and retrieve data, you will run a small Node.js application
- that loads data into, and then retrieves that data from the QIX Engine.
+ that loads data into, and then retrieves that data from the Qlik Associative Engine.
 
 The application consists of the `hello-engine.js` file and the `package.json`
 file, which is also shared among the Hello Data and
@@ -48,12 +48,12 @@ Hello Visualization tutorials.
     ```
 
     This command runs the application, which creates a representation
-    of the data and loads it into QIX Engine as a part of opening a session.
+    of the data and loads it into Qlik Associative Engine as a part of opening a session.
 
 ## What is happening
 
-When you start QIX Engine, the `docker-compose.yml` file makes the movies.csv file
-available to QIX Engine, and the data location is specified in the volumes section.
+When you start Qlik Associative Engine, the `docker-compose.yml` file makes the movies.csv file
+available to Qlik Associative Engine, and the data location is specified in the volumes section.
 
 ```yml
 volumes:
@@ -65,7 +65,7 @@ volumes:
 
 To load the data, the `hello-data` application uses
 [halyard.js](https://github.com/qlik-oss/halyard.js) to create
-a representation of the data and loads it into the QIX Engine as part of opening a session.
+a representation of the data and loads it into the Qlik Associative Engine as part of opening a session.
 Then, it uses enigma.js _mixin_ support to create a session
 object that holds the first 10 movie titles from the `movies.csv` dataset.
 The application then retrieves the movie titles from the dataset, prints the results, and closes the session.
@@ -93,13 +93,13 @@ Session closed.
 ```
 
 **Tip:** Open the `hello-data.js` file to see how enigma.js and
-halyard.js are used to load to and retrieve data from the QIX Engine.
+halyard.js are used to load to and retrieve data from the Qlik Associative Engine.
 
 **Note:** You might see some unfamiliar details of
-the QIX Engine in the source code.
+the Qlik Associative Engine in the source code.
 For example, the `properties` object that is used to create the session object
 contains a field called `qHyperCubeDef`. This relates to the
-central concept of _hypercubes_ in the QIX Engine.
+central concept of _hypercubes_ in the Qlik Associative Engine.
 To learn more about hypercubes, see
 [Hypercubes](http://help.qlik.com/en-US/sense-developer/Subsystems/Platform/Content/Concepts/Hypercubes.htm).
 

--- a/docs/docs/tutorials/hello-engine.md
+++ b/docs/docs/tutorials/hello-engine.md
@@ -1,6 +1,7 @@
 # Hello Engine
 
-Get started by running the QIX Engine in a Docker container on your local machine and communicating with it using [enigma.js](https://github.com/qlik-oss/enigma.js).
+Get started by running the Qlik Associative Engine in a Docker container on your local machine and
+communicating with it using [enigma.js](https://github.com/qlik-oss/enigma.js).
 
 ## Prerequisites
 
@@ -11,7 +12,7 @@ and all commands should be executed from this Git repository.
 
 You must have [Node.js](https://nodejs.org/en/) and npm installed on your local machine.
 
-## Starting the QIX Engine service
+## Starting the Qlik Associative Engine service
 
 1. Start the engine in a Docker container.
     Run the following command in a command shell:
@@ -53,7 +54,7 @@ It specifies how the engine runs as a Docker container, using the `qlik/engine` 
 
 **Tip:** To learn more about Docker compose files, see [Compose file](https://docs.docker.com/compose/compose-file/).
 
-## Communicating with the QIX Engine
+## Communicating with the Qlik Associative Engine
 
 To communicate with the engine in a Docker container, we use a small node.js application that uses
 [enigma.js](https://github.com/qlik-oss/enigma.js) to retrieve the engine version number.
@@ -79,7 +80,8 @@ which is also shared among the Hello Data and Hello Visualization tutorials.
     npm run hello-engine
     ```
 
-    This command runs the application, which communicates with QIX Engine and retrieves the engine semantic version.
+    This command runs the application, which communicates with Qlik Associative Engine and retrieves the
+    engine semantic version.
     If successful, you will see a response like the following:
 
     ```bash
@@ -90,7 +92,7 @@ which is also shared among the Hello Data and Hello Visualization tutorials.
     ```
 
     **Tip:** Open the [hello-engine.js](https://github.com/qlik-ea/getting-started-with-web-platform/blob/master/src/hello-engine/hello-engine.js)
-    file to see how enigma.js is configured to communicate with the QIX Engine.
+    file to see how enigma.js is configured to communicate with the Qlik Associative Engine.
 
 1. Stop and remove the Docker container.
 
@@ -106,7 +108,7 @@ which is also shared among the Hello Data and Hello Visualization tutorials.
 
 ## Next Steps
 
-Continue with the [Hello Data](./hello-data.md) tutorial to learn how to load data into the QIX Engine.
+Continue with the [Hello Data](./hello-data.md) tutorial to learn how to load data into the Qlik Associative Engine.
 Hello Data is a continuation of this tutorial.
 
 **Tip:** To learn more about enigma.js,

--- a/docs/docs/tutorials/hello-visualization.md
+++ b/docs/docs/tutorials/hello-visualization.md
@@ -1,6 +1,6 @@
 # Hello Visualization
 
-Build a data visualization from data loaded into a QIX Engine running inside a Docker container.
+Build a data visualization from data loaded into a Qlik Associative Engine running inside a Docker container.
 
 ## Prerequisites
 
@@ -9,15 +9,15 @@ to your local machine. The *Hello* tutorials are located here, and all commands 
 
 You must have [Node.js](https://nodejs.org/en/) and npm installed on your local machine.
 
-**Note:** Make sure the QIX Engine is running and that you have loaded data into the QIX Engine.
-If you are unfamiliar with starting the QIX Engine in a Docker container and loading data,
+**Note:** Make sure the Qlik Associative Engine is running and that you have loaded data into the Qlik Associative Engine.
+If you are unfamiliar with starting the Qlik Associative Engine in a Docker container and loading data,
 we recommend that you begin with the [Hello Engine](./hello-engine.md) tutorial followed by the
 [Hello Data](./hello-data.md) tutorial.
 
 ## Building a visualization
 
 To build a visualization, you will run a small Node.js application
-that creates a visualization from the data loaded into your dockerized QIX Engine.
+that creates a visualization from the data loaded into your dockerized Qlik Associative Engine.
 
 1. Install dependencies.
 
@@ -53,7 +53,7 @@ that creates a visualization from the data loaded into your dockerized QIX Engin
 ## What is happening
 
 When you run `Hello Visualization`, app.js creates and populates a session app
-from the data that is available to the QIX Engine using enigma.js
+from the data that is available to the Qlik Associative Engine using enigma.js
 to communicate with the engine and halyard.js to manage the data.
 A session app only lives while the session is alive.
 
@@ -64,9 +64,9 @@ to load and retrieve the movies data from the engine.
 
 ## Next Steps
 
-Now that you have seen how to start the QIX Engine in a Docker container,
+Now that you have seen how to start the Qlik Associative Engine in a Docker container,
 load data, and build a visualization from that data,
 we recommend that you explore the [Orchestration](./orchestration.md) tutorial,
 which shows how to run all core services of Qlik Core together.
-This will cover important topics such as how to run several QIX Engine instances using
+This will cover important topics such as how to run several Qlik Associative Engine instances using
 different container orchestration platforms.

--- a/docs/docs/tutorials/orchestration.md
+++ b/docs/docs/tutorials/orchestration.md
@@ -5,7 +5,7 @@ comprising the core services. The core services represent the foundation on whic
 
 The core Qlik Core stack consists of the following services:
 
-- [QIX Engine](../services/qix-engine/introduction.md)
+- [Qlik Associative Engine](../services/qix-engine/introduction.md)
 - [License Service](../services/license-service.md)
 - [Mira](../services/mira.md)
 
@@ -23,23 +23,23 @@ All commands should be executed from this Git repository.
 ## Licensing
 
 During beta, Qlik Core will not require licensing credentials. However, we highly
-recommend that you configure QIX Engine to use the license service which will
+recommend that you configure Qlik Associative Engine to use the license service which will
 enable you to transition out of the beta easily.
 
-On top of this, during beta each QIX Engine version will have a 30 day expiration (from
+On top of this, during beta each Qlik Associative Engine version will have a 30 day expiration (from
 when it was published), it will stop working after this time so make sure you can update
 and deploy often.
 
-When the QIX Engine is running, it periodically communicates with the License Service
+When the Qlik Associative Engine is running, it periodically communicates with the License Service
 to verify that it is running with a valid license.
-A QIX Engine deployment must be configured with the URL
+A Qlik Associative Engine deployment must be configured with the URL
 that is used to call the License Service REST API.
 You can do this by providing the `LicenseServiceUrl` setting.
 See the orchestration examples below how that works for your targeted environment.
 
-## Configuring the QIX Engine
+## Configuring the Qlik Associative Engine
 
-You supply configuration to QIX Engine by adding `-S <setting>=<value>` arguments
+You supply configuration to Qlik Associative Engine by adding `-S <setting>=<value>` arguments
 during startup. In a `docker-compose.yml` file it may look something like this.
 
 ```yml
@@ -52,7 +52,7 @@ services:
 ...
 ```
 
-To start QIX Engine in Qlik Core, you also need to accept the [EULA](../../beta.md) by
+To start Qlik Associative Engine in Qlik Core, you also need to accept the [EULA](../../beta.md) by
 supplying `-S AcceptEULA=yes`.
 
 ## Container orchestration
@@ -91,7 +91,7 @@ eval $(docker-machine env <swarm manager node>)
 
 The Qlik Core stack is specified in the
 [docker-compose.yml](https://github.com/qlik-ea/core/blob/master/docker-swarm/docker-compose.yml) file.
-The stack consists of one QIX Engine, one Mira discovery service, and one License Service.
+The stack consists of one Qlik Associative Engine, one Mira discovery service, and one License Service.
 
 #### Placement constraints
 
@@ -107,8 +107,8 @@ Relevant APIs are exposed on the following ports:
 | --------------- |:-------------:| --------------------------:|
 | Mira            | `9100`        | REST API                   |
 | License Service | `9200`        | REST API                   |
-| QIX Engine      | `9076`        | QIX websocket API          |
-| QIX Engine      | `9090`        | Prometheus/metric endpoint |
+| Qlik Associative Engine      | `9076`        | QIX websocket API          |
+| Qlik Associative Engine      | `9090`        | Prometheus/metric endpoint |
 
 These ports are exposed outside of the swarm
 so that they are easily available for demonstrations.
@@ -116,7 +116,7 @@ This is not a requirement.
 
 #### Labeling
 
-The QIX Engine service requires the following note to be added
+The Qlik Associative Engine service requires the following note to be added
 to the labels definition in the `docker-compose.yml` file:
 
 ```yml
@@ -124,7 +124,7 @@ labels:
   qix-engine: ""
 ```
 
-This label is required for Mira to identify service as a QIX Engine instance.
+This label is required for Mira to identify service as a Qlik Associative Engine instance.
 To learn more about labeling, see [Mira documentation](https://github.com/qlik-ea/mira).
 
 ### Deploying the stack
@@ -147,13 +147,13 @@ you can retrieve a list of the tasks running on the stack by running the followi
 docker stack ps qlik-core
 ```
 
-You can query Mira to return the list of QIX Engines it has discovered by calling its `/engines` endpoint:
+You can query Mira to return the list of Qlik Associative Engines it has discovered by calling its `/engines` endpoint:
 
 ```sh
 curl http://<swarm manager node ip>:9100/v1/engines
 ```
 
-This endpoint returns one or more QIX Engine instances and information about these instances in JSON format.
+This endpoint returns one or more Qlik Associative Engine instances and information about these instances in JSON format.
 
 ## Deploying to Kubernetes
 
@@ -185,7 +185,7 @@ This prevents the command from being stored in the Bash shell command history.
 ### The Stack
 
 The Qlik Core stack is specified in the `docker-compose.yml` file.
-The stack consists of one QIX Engine, one Mira discovery service, and one License Service.
+The stack consists of one Qlik Associative Engine, one Mira discovery service, and one License Service.
 
 #### Mira Kubernetes mode
 
@@ -208,23 +208,24 @@ Relevant APIs are exposed on the following ports:
 | --------------- |:-------------:| --------------------------:|
 | Mira            | `9100`        | REST API                   |
 | License Service | `9200`        | REST API                   |
-| QIX Engine      | `9076`        | QIX websocket API          |
-| QIX Engine      | `9090`        | Prometheus/metric endpoint |
+| Qlik Associative Engine      | `9076`        | QIX websocket API          |
+| Qlik Associative Engine      | `9090`        | Prometheus/metric endpoint |
 
 These ports are exposed outside of the swarm so that they are easily available for demonstrations.
 This is not a requirement.
 
 #### Labeling
 
-The QIX Engine service requires the following note to be added to the labels definition in the `engine-deployment.yml` file:
+The Qlik Associative Engine service requires the following note to be added to the labels definition in
+the `engine-deployment.yml` file:
 
 ```yml
 labels:
   qix-engine: ""
 ```
 
-This label is required for Mira to identify the engine service as a QIX Engine instance.
-To learn more about labeling, see [QIX Engine labeling](../services/mira.md#qix-engine-labeling).
+This label is required for Mira to identify the engine service as a Qlik Associative Engine instance.
+To learn more about labeling, see [Qlik Associative Engine labeling](../services/mira.md#qix-engine-labeling).
 
 ### Deploying the stack
 
@@ -265,13 +266,13 @@ you can retrieve a list of the tasks running on the stack by running the followi
 kubectl get all
 ```
 
-You can query Mira to return the list of QIX Engines it has discovered by calling its `/engines` endpoint:
+You can query Mira to return the list of Qlik Associative Engines it has discovered by calling its `/engines` endpoint:
 
 ```sh
 curl http://<kubernetes node ip>:9100/v1/engines
 ```
 
-This endpoint returns one or more QIX Engine instances and information about these instances in JSON format.
+This endpoint returns one or more Qlik Associative Engine instances and information about these instances in JSON format.
 
 ## Deploying to Nomad
 
@@ -298,7 +299,7 @@ To see an example of how the Nomad client can be configured to use local Docker 
 In a Nomad orchestration, Mira uses the DNS mode for service discovery.
 A Consul server must be running in the Nomad environment.
 Nomad will automatically register services in Consul when deploying the nomad files.
-You can find the hostname that Mira should use for discovering QIX Engine instances
+You can find the hostname that Mira should use for discovering Qlik Associative Engine instances
 in the task configuration of
 [mira.noamd](https://github.com/qlik-ea/core/blob/master/nomad/mira.nomad) file.
 

--- a/docs/docs/tutorials/scalability/newspaper.md
+++ b/docs/docs/tutorials/scalability/newspaper.md
@@ -29,15 +29,15 @@ We make the following assumptions in this example.
 
 - __Hosts/nodes__
 
-    There is a predefined set of hosts/nodes running QIX Engine.
+    There is a predefined set of hosts/nodes running Qlik Associative Engine.
     If unused, they are idling awaiting workload.
 
-- __Loading QIX Engine nodes__
+- __Loading Qlik Associative Engine nodes__
 
-    It is expected that documents can be loaded on all of the QIX Engine nodes,
+    It is expected that documents can be loaded on all of the Qlik Associative Engine nodes,
     or that the nodes are pre-populated with the documents.
 
-    Having the documents already loaded on the QIX Engine nodes
+    Having the documents already loaded on the Qlik Associative Engine nodes
     would improve speed and removes the need to continuously check whether there is enough resource
     headroom.
 
@@ -51,23 +51,23 @@ Given the assumptions specified above,
 RAM and CPU are important metrics for
 determining how to scale the system and where to place new sessions.
 
-New sessions should be placed on the QIX Engine node that has the most headroom and least amount of load.
+New sessions should be placed on the Qlik Associative Engine node that has the most headroom and least amount of load.
 A simple least-load principle could be applied to
-properly place a new user on the appropriate QIX Engine node.
+properly place a new user on the appropriate Qlik Associative Engine node.
 
 You can do this by using the [Mira service](../../services/mira.md) to return an array
-of available QIX Engine instances and then sort them by load.
+of available Qlik Associative Engine instances and then sort them by load.
 
 **Note:** In this scenario, it is assumed that the document is either already open or small
 enough to not cause RAM issues.
 
 A document session placement algorithm does the following:
 
-1. Get QIX Engine instances from Mira and sort them by least load.
-1. Sort the QIX Engine instances by the most free RAM.
-1. If multiple QIX Engines have the same amount of free RAM,
-    then sort the QIX Engine instances by CPU consumption.
-1. Choose the QIX Engine instance with the least amount of load (RAM and CPU).
+1. Get Qlik Associative Engine instances from Mira and sort them by least load.
+1. Sort the Qlik Associative Engine instances by the most free RAM.
+1. If multiple Qlik Associative Engines have the same amount of free RAM,
+    then sort the Qlik Associative Engine instances by CPU consumption.
+1. Choose the Qlik Associative Engine instance with the least amount of load (RAM and CPU).
 
 ```javascript
 //RAM free takes priority, but if equal then CPU is the deciding factor
@@ -88,7 +88,7 @@ function compareResources(a, b) {
 function getLeastLoadedQixEngine() {
   const qixEngines = []; // retrieved from your Mira service
   var sortedQIXEngines = qixEngines.sort(compareResources);
-  console.log("QIX Engine selected: "+ sortedQIXEngines[0].engine.ip);
+  console.log("Qlik Associative Engine selected: "+ sortedQIXEngines[0].engine.ip);
   return sortedQIXEngines[0].engine.ip;
 }
 ```

--- a/docs/docs/tutorials/scalability/overview.md
+++ b/docs/docs/tutorials/scalability/overview.md
@@ -5,8 +5,8 @@ These real-world implementations will help you understand your requirements when
 
 ## Before you begin
 
-We recommended that you start by reading the [QIX Engine documentation](./../../services/qix-engine/introduction.md),
-which will help you understand how the QIX Engine handles resources and interacts with other services.
+We recommended that you start by reading the [Qlik Associative Engine documentation](./../../services/qix-engine/introduction.md),
+which will help you understand how the Qlik Associative Engine handles resources and interacts with other services.
 
 ## Use cases
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@
 </div>
 
 <div class="marketing-text">
-    <p>Get the power in QIX Engine in the way you need it. With our containerized
-    QIX Engine we are giving you the most flexible solution ever for data
+    <p>Get the power in Qlik Associative Engine in the way you need it. With our containerized
+    Qlik Associative Engine we are giving you the most flexible solution ever for data
     discovery. Qlik Core is ready for Cloud deployment and has a large set of examples
     and use cases that will help you with your development Qlik Core is
     for everyone with a data problem.</p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,7 @@ pages:
         - Overview: docs/tutorials/scalability/overview.md
         - Newspaper website: docs/tutorials/scalability/newspaper.md
     - Services:
-      - QIX Engine:
+      - Qlik Associative Engine:
         - Introduction: docs/services/qix-engine/introduction.md
         #- Access Control: docs/services/qix-engine/access-control.md
         #- Document Synchronization: docs/services/qix-engine/doc-synchronization.md


### PR DESCRIPTION
The official (non-technical) name for QIX Engine is Qlik Associative Engine according to branding guidelines.