### PR TITLE
Do not run proselint on generated files

### DIFF
--- a/docs/.lint-condo.yaml
+++ b/docs/.lint-condo.yaml
@@ -1,3 +1,4 @@
 linters:
   - markdownlint . # Markdown syntax linting
-  - proselint docs/. # English prose linting
+  # The magic parameter filters out all files that has 'proselint-disable' in them
+  - proselint $(grep -L "proselint-disable" -r . | grep .md) # English prose linting

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 BETA SOFTWARE LICENSE AGREEMENT
 ===============================
 

--- a/docs/docs/services/qix-engine/apis/qix/definitions.md
+++ b/docs/docs/services/qix-engine/apis/qix/definitions.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # Definitions
 
 _QIX definitions for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/doc.md
+++ b/docs/docs/services/qix-engine/apis/qix/doc.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # Doc
 
 _QIX methods for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/field.md
+++ b/docs/docs/services/qix-engine/apis/qix/field.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # Field
 
 _QIX methods for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/genericbookmark.md
+++ b/docs/docs/services/qix-engine/apis/qix/genericbookmark.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # GenericBookmark
 
 _QIX methods for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/genericderivedfields.md
+++ b/docs/docs/services/qix-engine/apis/qix/genericderivedfields.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # GenericDerivedFields
 
 _QIX methods for version 12.101.0._

--- a/docs/docs/services/qix-engine/apis/qix/genericdimension.md
+++ b/docs/docs/services/qix-engine/apis/qix/genericdimension.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # GenericDimension
 
 _QIX methods for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/genericmeasure.md
+++ b/docs/docs/services/qix-engine/apis/qix/genericmeasure.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # GenericMeasure
 
 _QIX methods for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/genericobject.md
+++ b/docs/docs/services/qix-engine/apis/qix/genericobject.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # GenericObject
 
 _QIX methods for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/genericvariable.md
+++ b/docs/docs/services/qix-engine/apis/qix/genericvariable.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # GenericVariable
 
 _QIX methods for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/global.md
+++ b/docs/docs/services/qix-engine/apis/qix/global.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # Global
 
 _QIX methods for version 12.145.0._

--- a/docs/docs/services/qix-engine/apis/qix/variable.md
+++ b/docs/docs/services/qix-engine/apis/qix/variable.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable -->
+<!-- proselint-disable -->
 # Variable
 
 _QIX methods for version 12.145.0._

--- a/generate-beta-page.sh
+++ b/generate-beta-page.sh
@@ -20,4 +20,4 @@ $docker_cmd run --rm -it -v $pwd:/pandoc dalibo/pandocker:latest \
   -o docs/beta.md
 
 content=$(cat docs/beta.md)
-echo -e "<!-- markdownlint-disable -->\n$content" > docs/beta.md
+echo -e "<!-- markdownlint-disable -->\n<!-- proselint-disable -->\n$content" > docs/beta.md


### PR DESCRIPTION
Some reverse engineering in the lint-condo/proselint configurations showed that you could use arbitrary bash logic instead of simple glob patterns/static file references in the configuration/execution of the linters... So why not abuse it a little.

* We can now ignore specific files by adding `<!-- proselint-disable -->` to them, just as we can do `<!-- markdownlint-disable -->`.
* Improves `./lint.sh` performance a lot, from ~40 seconds to ~16 seconds on my machine
