### PR TITLE
Update licenses doc alternative 2

### DIFF
--- a/docs/docs/services/licenses.md
+++ b/docs/docs/services/licenses.md
@@ -14,7 +14,8 @@ It is developed by Qlik as closed source.
 
 ## Configuration
 
-You need to configure the Licenses service with two environment variables `LICENSES_SERIAL_NBR` with your LEF serial number and `LICENSES_CONTROL_NBR` with your LEF control number.
+You need to configure the Licenses service with two environment variables `LICENSES_SERIAL_NBR`
+with your LEF serial number and `LICENSES_CONTROL_NBR` with your LEF control number.
 
 You also need to configure [Qlik Associative Engine](./qix-engine/introduction.md)
 where to find it. You can do this by passing the following command line argument to the Qlik
@@ -26,7 +27,8 @@ Associative Engine.
 
 ## Examples
 
-To see an example of a license configuration, see the [core-using-licenses](https://github.com/qlik-oss/core-using-licenses) repository.
+To see an example of a license configuration, see the
+[core-using-licenses](https://github.com/qlik-oss/core-using-licenses) repository.
 
 ## Deployment
 
@@ -54,7 +56,8 @@ metrics associated with your license:
 | license_time_consumption | GAUGE | Number of license minutes consumed this month. This metrics is only showed if any minutes have been consumed. |
 | license_time_total | GAUGE | The total amount of license minutes per month your license gives you. |
 
-To see an example of how you can use these metrics to create dashboards of your license consumption, see the [core-using-licenses](https://github.com/qlik-oss/core-using-licenses) repository.
+To see an example of how you can use these metrics to create dashboards of your license consumption,
+see the [core-using-licenses](https://github.com/qlik-oss/core-using-licenses) repository.
 
 ### Logging
 
@@ -65,6 +68,8 @@ You can override the minimum logging level by providing the `LICENSES_LOG_LEVEL`
 
 ### License Events
 
-If no valid license exists or all license minutes are already consumed and the Qlik Associative Engine is configured to run in licensed mode it will send a `SESSION_ERROR_NO_LICENSE` push event on the websocket and then close it.
+If no valid license exists or all license minutes are already consumed and the Qlik Associative Engine
+is configured to run in licensed mode it will send a `SESSION_ERROR_NO_LICENSE` push event on the websocket and then close it.
 
-If during a license renewal there are no more license minutes a `SESSION_ERROR_LICENSE_RENEW` push event will be sent from the Qlik Associative Engine and afterwards the websocket will be closed.
+If during a license renewal there are no more license minutes a `SESSION_ERROR_LICENSE_RENEW`
+push event will be sent from the Qlik Associative Engine and afterwards the websocket will be closed.

--- a/docs/docs/services/licenses.md
+++ b/docs/docs/services/licenses.md
@@ -4,6 +4,9 @@
     This service is subject to change in terms of
     configuration, metrics, and logging.
 
+!!! Note "Tutorial"
+    A tutorial on how to set up the licenses service can be found (here)[../tutorials/licensing.md]
+
 To run Qlik Associative Engine with a paid license, you are required to run this service.
 
 ## Distribution

--- a/docs/docs/services/licenses.md
+++ b/docs/docs/services/licenses.md
@@ -5,7 +5,7 @@
     configuration, metrics, and logging.
 
 !!! Note "Tutorial"
-    A tutorial on how to set up the licenses service can be found (here)[../tutorials/licensing.md]
+    A tutorial on how to set up the licenses service can be found [here](../tutorials/licensing.md)
 
 To run Qlik Associative Engine with a paid license, you are required to run this service.
 

--- a/docs/docs/services/licenses.md
+++ b/docs/docs/services/licenses.md
@@ -69,7 +69,8 @@ You can override the minimum logging level by providing the `LICENSES_LOG_LEVEL`
 ### License Events
 
 If no valid license exists or all license minutes are already consumed and the Qlik Associative Engine
-is configured to run in licensed mode it will send a `SESSION_ERROR_NO_LICENSE` push event on the websocket and then close it.
+is configured to run in licensed mode it will send a `SESSION_ERROR_NO_LICENSE`
+push event on the websocket and then close it.
 
 If during a license renewal there are no more license minutes a `SESSION_ERROR_LICENSE_RENEW`
 push event will be sent from the Qlik Associative Engine and afterwards the websocket will be closed.

--- a/docs/docs/services/licenses.md
+++ b/docs/docs/services/licenses.md
@@ -14,8 +14,9 @@ It is developed by Qlik as closed source.
 
 ## Configuration
 
-You do not need to configure this service right now but this will be required in the future.
-In addition, you do need to configure [Qlik Associative Engine](./qix-engine/introduction.md)
+You need to configure the Licenses service with two environment variables `LICENSES_SERIAL_NBR` with your LEF serial number and `LICENSES_CONTROL_NBR` with your LEF control number.
+
+You also need to configure [Qlik Associative Engine](./qix-engine/introduction.md)
 where to find it. You can do this by passing the following command line argument to the Qlik
 Associative Engine.
 
@@ -25,7 +26,7 @@ Associative Engine.
 
 ## Examples
 
-To see an example of a basic license configuration, see the [Orchestration](../tutorials/orchestration.md) tutorial.
+To see an example of a license configuration, see the [core-using-licenses](https://github.com/qlik-oss/core-using-licenses) repository.
 
 ## Deployment
 
@@ -35,28 +36,35 @@ support multiple instances if needed.
 
 ### Health check
 
-For health checking, the service exposes `/v1/health` on port 9200, and it always responds with `200 OK`.
+For health checking, the service exposes `/health` on port 9200, and it always responds with:
+
+``` json
+{
+"alive": true
+}
+```
 
 ### Metrics
 
-For Prometheus metrics scraping, the service exposes `/v1/metrics` on port 9200. It provides the following
-metrics:
+For Prometheus metrics scraping, the service exposes `/metrics` on port 9200. It provides the following
+metrics associated with your license:
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| http_requests_total | COUNTER | Total number of HTTP requests since service start.<br>It includes both successful and unsuccessful requests.<br>The HTTP method and endpoint path are provided as labels. |
-| http_request_failures_total | COUNTER | Total number of HTTP request failures since service start.<br>The HTTP method and endpoint path are provided as labels |
-| http_request_duration_seconds | HISTOGRAM | Durations of HTTP request since service start.<br>The HTTP method and endpoint path are provided as labels. |
-| active_instances | GAUGE | Number of active instances (engines with an active license). |
-| license_expiry_seconds | GAUGE | Number of seconds until the license expires. |
+| license_time_consumption | GAUGE | Number of license minutes consumed this month. This metrics is only showed if any minutes have been consumed. |
+| license_time_total | GAUGE | The total amount of license minutes per month your license gives you. |
+
+To see an example of how you can use these metrics to create dashboards of your license consumption, see the [core-using-licenses](https://github.com/qlik-oss/core-using-licenses) repository.
 
 ### Logging
 
 This service complies with the [Logging](../conventions/logging.md) conventions.
 By default, the minimum log level is `info`.
-However, for Microsoft libraries, the default minimum logging level is set to `warning` to avoid too verbose logging.
 
-You can override the minimum logging level by providing the `LOG_LEVEL` environment variable.
-Note that if you provide this variable it will affect the logging level for all components in the License Service,
-including Microsoft libraries. We recommend that you use the default minimum level in a production environment,
-and only override the level for debugging purposes.
+You can override the minimum logging level by providing the `LICENSES_LOG_LEVEL` environment variable.
+
+### License Events
+
+If no valid license exists or all license minutes are already consumed and the Qlik Associative Engine is configured to run in licensed mode it will send a `SESSION_ERROR_NO_LICENSE` push event on the websocket and then close it.
+
+If during a license renewal there are no more license minutes a `SESSION_ERROR_LICENSE_RENEW` push event will be sent from the Qlik Associative Engine and afterwards the websocket will be closed.

--- a/docs/docs/services/licenses.md
+++ b/docs/docs/services/licenses.md
@@ -14,21 +14,17 @@ It is developed by Qlik as closed source.
 
 ## Configuration
 
-You need to configure the Licenses service with two environment variables `LICENSES_SERIAL_NBR`
-with your LEF serial number and `LICENSES_CONTROL_NBR` with your LEF control number.
+You configure Licenses by setting environment variables inside the container.
 
-You also need to configure [Qlik Associative Engine](./qix-engine/introduction.md)
-where to find it. You can do this by passing the following command line argument to the Qlik
-Associative Engine.
+### Environment variables
 
-```sh
--S LicenseServiceUrl=<Licenses service URL>
-```
+The following environment variables can be set when using the license service in Qlik Core mode:
 
-## Examples
-
-To see an example of a license configuration, see the
-[core-using-licenses](https://github.com/qlik-oss/core-using-licenses) repository.
+| Name                                  |Required| Default value           | Description |
+| ------------------------------------- |--------| ----------------------- | ----------- |
+| LICENSES_SERIAL_NBR                   | yes | N/A                     | The License serial number. |
+| LICENSES_CONTROL_NBR                  | yes |N/A                     | The License control number. |
+| LICENSES_LOG_LEVEL                    | no |info                    | Minimum log level that Licenses outputs when logging to `stdout`. |
 
 ## Deployment
 
@@ -42,8 +38,10 @@ For health checking, the service exposes `/health` on port 9200, and it always r
 
 ### Metrics
 
-For Prometheus metrics scraping, the service exposes `/metrics` on port 9200. It provides the following
-metrics associated with your license:
+Following the [Metrics](../conventions/metrics.md) conventions, Licenses exposes
+some metrics that can be used to monitor the service on port 9200.
+It provides the following specific
+metrics associated with your Qlik Core license:
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -59,12 +57,3 @@ This service complies with the [Logging](../conventions/logging.md) conventions.
 By default, the minimum log level is `info`.
 
 You can override the minimum logging level by providing the `LICENSES_LOG_LEVEL` environment variable.
-
-### License Events
-
-If no valid license exists or all license minutes are already consumed and the Qlik Associative Engine
-is configured to run in licensed mode it will send a `SESSION_ERROR_NO_LICENSE`
-push event on the websocket and then close it.
-
-If during a license renewal there are no more license minutes a `SESSION_ERROR_LICENSE_RENEW`
-push event will be sent from the Qlik Associative Engine and afterwards the websocket will be closed.

--- a/docs/docs/services/licenses.md
+++ b/docs/docs/services/licenses.md
@@ -40,9 +40,9 @@ support multiple instances if needed.
 
 For health checking, the service exposes `/health` on port 9200, and it always responds with:
 
-``` json
+```json
 {
-"alive": true
+    "alive": true
 }
 ```
 

--- a/docs/docs/services/licenses.md
+++ b/docs/docs/services/licenses.md
@@ -38,13 +38,7 @@ support multiple instances if needed.
 
 ### Health check
 
-For health checking, the service exposes `/health` on port 9200, and it always responds with:
-
-```json
-{
-    "alive": true
-}
-```
+For health checking, the service exposes `/health` on port 9200, and it always responds with http status code `200 OK`.
 
 ### Metrics
 

--- a/docs/docs/tutorials/licensing.md
+++ b/docs/docs/tutorials/licensing.md
@@ -1,0 +1,31 @@
+# Licensing
+
+In this small tutorial, you will learn how to set up the Licenses service together with the Qlik Associative Engine.
+
+## Configuration
+
+You need to configure the Licenses service with two environment variables `LICENSES_SERIAL_NBR`
+with your LEF serial number and `LICENSES_CONTROL_NBR` with your LEF control number.
+
+You also need to configure [Qlik Associative Engine](./qix-engine/introduction.md)
+where to find it. You can do this by passing the following command line argument to the Qlik
+Associative Engine.
+
+```sh
+-S LicenseServiceUrl=<Licenses service URL>
+```
+
+## Examples
+
+To see an example of a license configuration, see the
+[core-using-licenses](https://github.com/qlik-oss/core-using-licenses) repository.
+It contains examples of a setup with the license service and a Qlik Associative Engine, as well as runnable tests.
+
+## License Events
+
+If no valid license exists or all license minutes are already consumed and the Qlik Associative Engine
+is configured to run in licensed mode it will send a `SESSION_ERROR_NO_LICENSE`
+push event on the websocket and then close it.
+
+If during a license renewal there are no more license minutes a `SESSION_ERROR_LICENSE_RENEW`
+push event will be sent from the Qlik Associative Engine and afterwards the websocket will be closed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ pages:
       - Hello Engine: docs/tutorials/hello-engine.md
       - Hello Data: docs/tutorials/hello-data.md
       - Hello Visualization: docs/tutorials/hello-visualization.md
+      - Licensing: docs/tutorials/licensing.md
       - Orchestration: docs/tutorials/orchestration.md
       - Authorization: docs/tutorials/authorization.md
       - Data Loading: docs/tutorials/data-loading.md


### PR DESCRIPTION
In this PR we separate the information about the licensing into two parts.

A licensing tutorial part about how to set up your licensing with the engine 

And a licenses service part about the service itself.