### PR TITLE
Fix incorrect folder parsing in git bash (mingw64)

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -7,6 +7,10 @@ pwd=$(pwd)
 
 if [[ "$OS" == "Windows_NT" ]]; then
   docker_cmd="winpty docker"
+  if [[ "$MSYSTEM" == MINGW* ]]; then
+    pwd=`echo $pwd | sed 's/\//\/\//g'`
+    echo $pwd
+  fi
 fi
 
 $docker_cmd run --rm -v $pwd/docs/:/src/ -v $pwd/docs/.proselintrc:/root/.proselintrc -it singapore/lint-condo:0.18.0

--- a/lint.sh
+++ b/lint.sh
@@ -7,6 +7,7 @@ pwd=$(pwd)
 
 if [[ "$OS" == "Windows_NT" ]]; then
   docker_cmd="winpty docker"
+  pwd=/$(pwd -W)
 fi
 
-$docker_cmd run --rm -v /$pwd/docs/:/src/ -v /$pwd/docs/.proselintrc:/root/.proselintrc -it singapore/lint-condo:0.18.0
+$docker_cmd run --rm -v $pwd/docs/:/src/ -v $pwd/docs/.proselintrc:/root/.proselintrc -it singapore/lint-condo:0.18.0

--- a/lint.sh
+++ b/lint.sh
@@ -9,7 +9,6 @@ if [[ "$OS" == "Windows_NT" ]]; then
   docker_cmd="winpty docker"
   if [[ "$MSYSTEM" == MINGW* ]]; then
     pwd=`echo $pwd | sed 's/\//\/\//g'`
-    echo $pwd
   fi
 fi
 

--- a/lint.sh
+++ b/lint.sh
@@ -7,9 +7,6 @@ pwd=$(pwd)
 
 if [[ "$OS" == "Windows_NT" ]]; then
   docker_cmd="winpty docker"
-  if [[ "$MSYSTEM" == MINGW* ]]; then
-    pwd=`echo $pwd | sed 's/\//\/\//g'`
-  fi
 fi
 
-$docker_cmd run --rm -v $pwd/docs/:/src/ -v $pwd/docs/.proselintrc:/root/.proselintrc -it singapore/lint-condo:0.18.0
+$docker_cmd run --rm -v /$pwd/docs/:/src/ -v /$pwd/docs/.proselintrc:/root/.proselintrc -it singapore/lint-condo:0.18.0


### PR DESCRIPTION
In windows it is quite common to use git pash running commands. Unfortunately it isn't working nicely together with docker. The fix below changes how mingw parses folders and ensures that docker parses these correctly. If this is a bigger thing (more scripts affected) we should probably look for another solution.