### PR TITLE
Load Script doc: Put examples in bold and not as a section

### DIFF
--- a/docs/services/qix-engine/script_reference/basic_aggregation_functions.md
+++ b/docs/services/qix-engine/script_reference/basic_aggregation_functions.md
@@ -232,7 +232,7 @@ Canutility</p></td>
 </tbody>
 </table>
 
-### Mode
+## Mode
 
  **Mode()** returns the most commonly occurring value, the mode value, of the aggregated data in the expression, as
  defined by a group by clause. The **Mode()** function can return numeric values as well as text values.

--- a/docs/services/qix-engine/script_reference/counter_aggregation_functions.md
+++ b/docs/services/qix-engine/script_reference/counter_aggregation_functions.md
@@ -22,7 +22,7 @@ To get the same look as in the result column below, in the properties
 panel, under Sorting, switch from Auto to Custom, then deselect
 numerical and alphabetical sorting.
 
-### Example 1
+**Example 1**:
 
 Script:
 
@@ -58,7 +58,7 @@ Result:
 As long as the dimension Customer is included in the table on the sheet,
 otherwise the result for OrdersByCustomer is 3, 2.
 
-### Example 2
+**Example 2**:
 
 Given that the Temp table is loaded as in the previous example:
 
@@ -66,7 +66,7 @@ Given that the Temp table is loaded as in the previous example:
 | ---------------- |
 | 10 |
 
-### Example 3
+**Example 3**:
 
 Given that the Temp table is loaded as in the first example:
 
@@ -104,7 +104,7 @@ To get the same look as in the result column below, in the properties
 panel, under Sorting, switch from Auto to Custom, then deselect
 numerical and alphabetical sorting.
 
-### Example 1
+**Example 1**:
 
 Script:
 
@@ -146,7 +146,7 @@ The second statement gives:
 
 in a table with that dimension.
 
-### Example 2
+**Example 2**:
 
 Given that the Temp table is loaded as in the previous example:
 
@@ -184,7 +184,7 @@ To get the same look as in the result column below, in the properties
 panel, under Sorting, switch from Auto to Custom, then deselect
 numerical and alphabetical sorting.
 
-### Example
+**Example**:
 
 Script:
 
@@ -248,7 +248,7 @@ To get the same look as in the result column below, in the properties
 panel, under Sorting, switch from Auto to Custom, then deselect
 numerical and alphabetical sorting.
 
-### Example 1
+**Example 1**:
 
 ```code
 Temp:
@@ -277,7 +277,7 @@ LOAD Customer,NumericCount(OrderNumber) as NumericCountByCustomer Resident Temp 
 | Canutility | 0 |
 | Divadip | 2 |
 
-### Example 2
+**Example 2**:
 
 ```code
 LOAD NumericCount(OrderNumber) as TotalNumericCount Resident Temp;
@@ -291,7 +291,7 @@ The second statement gives:
 
 in a table with that dimension.
 
-### Example 3
+**Example 3**:
 
 Given that the Temp table is loaded as in the previous example:
 
@@ -329,7 +329,7 @@ To get the same look as in the result column below, in the properties
 panel, under Sorting, switch from Auto to Custom, then deselect
 numerical and alphabetical sorting.
 
-### Example
+**Example**:
 
 ```code
 Temp:

--- a/docs/services/qix-engine/script_reference/financial_aggregation_functions.md
+++ b/docs/services/qix-engine/script_reference/financial_aggregation_functions.md
@@ -29,7 +29,7 @@ Add the example script to your app and run it. Then add, at least, the
 fields listed in the results column to a sheet in your app to see the
 result.
 
-### Example
+**Example**:
 
 Script:
 
@@ -76,7 +76,7 @@ Add the example script to your app and run it. Then add, at least, the
 fields listed in the results column to a sheet in your app to see the
 result.
 
-### Example
+**Example**:
 
 Script:
 
@@ -142,7 +142,7 @@ Add the example script to your app and run it. Then add, at least, the
 fields listed in the results column to a sheet in your app to see the
 result.
 
-### Example
+**Example**:
 
 Script:
 
@@ -191,7 +191,7 @@ Add the example script to your app and run it. Then add, at least, the
 fields listed in the results column to a sheet in your app to see the
 result.
 
-### Example
+**Example**:
 
 Script:
 


### PR DESCRIPTION
If examples are defined as an header they appear in the table of contents. Lets put them in bold instead as the rest of the documentation.