### PR TITLE
Added reference to core-data-loading examples

### DIFF
--- a/docs/tutorials/data-loading/databases.md
+++ b/docs/tutorials/data-loading/databases.md
@@ -157,3 +157,8 @@ The biggest difference between the two database connection strings is the driver
     We recommend that you take a look inside the `index.js` file, and that you read through the
     [enigma.js](https://github.com/qlik-oss/enigma.js)
     documentation to get a better understanding of the steps in this tutorial.
+
+## Next steps
+
+More runnable load script examples, including more advanced ones, are available in the
+[qlik-oss/core-data-loading](https://github.com/qlik-oss/core-data-loading) Git repository.

--- a/docs/tutorials/data-loading/local-files.md
+++ b/docs/tutorials/data-loading/local-files.md
@@ -167,3 +167,8 @@ npm start load-renamed-fields
 The expected output is a list of airport entries, with the renamed fields,
 with only the explicitly listed headers in the CSV file.
 The other fields are not loaded into engine memory.
+
+## Next steps
+
+More runnable load script examples, including more advanced ones, are available in the
+[qlik-oss/core-data-loading](https://github.com/qlik-oss/core-data-loading) Git repository.

--- a/docs/tutorials/data-loading/remote-files.md
+++ b/docs/tutorials/data-loading/remote-files.md
@@ -84,3 +84,8 @@ node dropbox.js
 
 The expected output printed to the console is a list of 10 airport entries from the
 [airports.csv](https://github.com/qlik-oss/core-file-connectivity-service/blob/master/data/airports.csv) file.
+
+## Next steps
+
+More runnable load script examples, including more advanced ones, are available in the
+[qlik-oss/core-data-loading](https://github.com/qlik-oss/core-data-loading) Git repository.


### PR DESCRIPTION
It's a bit repetitive to have this as "Next steps" on each tutorial page.
I'm not sure where it is best placed. I think some reference to all the examples is valuable.