### PR TITLE
Update Mira documentation regarding access to the Kubernetes API

### DIFF
--- a/docs/services/mira.md
+++ b/docs/services/mira.md
@@ -203,10 +203,9 @@ You can enable _Kubernetes_ mode by setting the environment variable `MIRA_MODE`
 before starting the Mira pod.
 
 !!! Note
-    Since Mira needs to communicate with the Kubernetes API server,
-    a `kubectl` proxy should be set up in the Kubernetes deployment.
-    One way you can do this is to bundle the `kubectl` proxy as a container in the same pod as the Mira container,
-    then Mira can reach the proxy on `localhost`.
+    Mira uses the Kubernetes API to discover Qlik Associative Engines in a Kubernetes deployment.
+    If RBAC is enabled in Kubernetes then Mira will need `get` and `view`
+    access to the `pod`, `replicaset` and `deployment` APIs.
 
 ### Example of Kubernetes mode
 
@@ -228,9 +227,6 @@ file. With the `kubectl` command line tool, run the following command:
 ```sh
 kubectl apply -f mira-deployment.yml
 ```
-
-!!! Note
-    Mira and the `kubectl` proxy are bundled into the same pod.
 
 #### Expose Mira REST API
 

--- a/docs/services/mira.md
+++ b/docs/services/mira.md
@@ -204,8 +204,7 @@ before starting the Mira pod.
 
 !!! Note
     Mira uses the Kubernetes API to discover Qlik Associative Engines in a Kubernetes deployment.
-    If RBAC is enabled in Kubernetes then Mira will need `get` and `view`
-    access to the `pod`, `replicaset` and `deployment` APIs.
+    If RBAC is enabled in Kubernetes then Mira will need `view` access to the Kubernetes API.
 
 ### Example of Kubernetes mode
 

--- a/docs/tutorials/orchestration.md
+++ b/docs/tutorials/orchestration.md
@@ -161,11 +161,7 @@ Open the
 [mira-deployment.yaml](https://github.com/qlik-oss/core-orchestration/blob/master/kubernetes/plain/qlik-core/mira-deployment.yaml)
 file to see how Mira is configured.
 
-The Mira deployment specifies two containers to run in the pod.
-This is because Mira needs to communicate with the Kubernetes API server through *kubectl* as a proxy.
-
-Mira must also be configured to run in Kubernetes mode.
-This does not happen automatically.
+Mira must be configured to run in Kubernetes mode.
 To do this, you must set the environment variable `MIRA_MODE` to `kubernetes`.
 
 #### Ports


### PR DESCRIPTION
Since we are no longer using a sidecart container for Mira we need to update the documentation.