### PR TITLE
Adding early draft of tooling section

### DIFF
--- a/docs/tooling/catwalk.md
+++ b/docs/tooling/catwalk.md
@@ -1,0 +1,17 @@
+# Catwalk
+
+![catwalk](https://github.com/qlik-oss/catwalk/raw/master/src/assets/catwalk.svg)
+
+When you have created an initial load script you quickly end up in the data modelling problem space and might need to
+help to find out how the data is associated and how interactions with the data impacts the model. Catwalk is built to
+support this by providing you a view of all your tables, fields, their associations and information about the data
+within.
+
+![screenshot](https://github.com/qlik-oss/catwalk/raw/master/screenshot.png)
+
+## Usage
+
+You can either view your Qlik Core app by providing a link to an engine web socket at
+[catwalk](https://catwalk.core.qlik.com/)
+
+Or clone the [catwalk repo](https://github.com/qlik-oss/catwalk) and run the tool locally.

--- a/docs/tooling/catwalk.md
+++ b/docs/tooling/catwalk.md
@@ -1,13 +1,13 @@
 # Catwalk
 
-![catwalk](https://github.com/qlik-oss/catwalk/raw/master/src/assets/catwalk.svg)
+![catwalk](https://github.com/qlik-oss/catwalk/blob/master/src/assets/catwalk.svg)
 
 When you have created an initial load script you quickly end up in the data modelling problem space and might need to
 help to find out how the data is associated and how interactions with the data impacts the model. Catwalk is built to
 support this by providing you a view of all your tables, fields, their associations and information about the data
 within.
 
-![screenshot](https://github.com/qlik-oss/catwalk/raw/master/screenshot.png)
+![screenshot](https://github.com/qlik-oss/catwalk/blob/master/screenshot.png)
 
 ## Usage
 

--- a/docs/tooling/corectl.md
+++ b/docs/tooling/corectl.md
@@ -1,6 +1,6 @@
 # Corectl
 
-Qlik Core Command (corectl) is a command line tool with the goal to deliver a command line interface (CLI) for the Qlik
+Qlik Core Command (corectl) is a tool with the goal to deliver a command line interface (CLI) for the Qlik
 Associative Engine that can be used to interact with your apps, objects, and data.
 
 ![screenshot](../images/corectl.png)
@@ -10,9 +10,3 @@ The main use cases are:
 * View: List applications, view and query data within and evaluate expressions
 * Develop: Create, update and model a Qlik application
 * Script: Support scripting and automation of common tasks
-
-## View
-
-## Develop
-
-## Script

--- a/docs/tooling/corectl.md
+++ b/docs/tooling/corectl.md
@@ -1,0 +1,18 @@
+# Corectl
+
+Qlik Core Command (corectl) is a command line tool with the goal to deliver a command line interface (CLI) for the Qlik
+Associative Engine that can be used to interact with your apps, objects, and data.
+
+![screenshot](../images/corectl.png)
+
+The main use cases are:
+
+* View: List applications, view and query data within and evaluate expressions
+* Develop: Create, update and model a Qlik application
+* Script: Support scripting and automation of common tasks
+
+## View
+
+## Develop
+
+## Script

--- a/docs/tooling/overview.md
+++ b/docs/tooling/overview.md
@@ -1,0 +1,12 @@
+# Overview
+
+Beside offering examples, tutorials and documentation for creating solutions with Qlik Core we have also created a set
+of tools for designing, developing and viewing artifacts within the Qlik Associative Engine. They are not required to
+build a Qlik Core solution but will support in development.
+
+Tool                      | Description
+------------------------- | -----------
+[corectl](./corectl.md)   | Core Control (corectl) is a command line which can perform commands on a Qlik Core app such
+as reload, fetch metadata and evaluate expressions.
+[Catwalk](./catwalk.md)   | A data modelling tool which gives a graphical representation of the data model within an
+application

--- a/docs/tooling/overview.md
+++ b/docs/tooling/overview.md
@@ -6,7 +6,5 @@ build a Qlik Core solution but will support in development.
 
 Tool                      | Description
 ------------------------- | -----------
-[corectl](./corectl.md)   | Core Control (corectl) is a command line which can perform commands on a Qlik Core app such
-as reload, fetch metadata and evaluate expressions.
-[Catwalk](./catwalk.md)   | A data modelling tool which gives a graphical representation of the data model within an
-application
+[corectl](./corectl.md)   | Qlik Core Control (corectl) is a command line which can perform commands on a Qlik Core app such as reload, fetch metadata and evaluate expressions.
+[Catwalk](./catwalk.md)   | A data modelling tool which gives a graphical representation of the data model within an application

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ nav:
   - Tooling:
     - Overview: tooling/overview.md
     - corectl: tooling/corectl.md
-    - catwalk: tooling/catwalk.md  
+    - Catwalk: tooling/catwalk.md  
   - Services:
     - Mira: services/mira.md
     - Qlik Associative Engine:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,10 @@ nav:
       - Local Files: tutorials/data-loading/local-files.md
       - Remote Files: tutorials/data-loading/remote-files.md
       - Databases: tutorials/data-loading/databases.md
+  - Tooling:
+    - Overview: tooling/overview.md
+    - corectl: tooling/corectl.md
+    - catwalk: tooling/catwalk.md  
   - Services:
     - Mira: services/mira.md
     - Qlik Associative Engine:


### PR DESCRIPTION
Adding a suggestion on how to setup a tooling section on the site. The idea is to provide a top level reason for the tool's existence (use cases) not a documentation of the tool (that should go in the repo). 

Focus on background and structure first, I will look into the text later.

Thoughts to reflect upon
- Should we have a separate tooling chapter or should this go as part of download (I prefer not)
- Is this a good scope? Does it help the users

Fixes #427 