### PR TITLE
Update docs for mira 2.0

### DIFF
--- a/docs/services/mira.md
+++ b/docs/services/mira.md
@@ -32,7 +32,7 @@ The following environment variables can optionally be set:
 | MIRA_DISCOVERY_HOSTNAME               | n/a                     | Hostname that Mira uses to query DNS for Qlik Associative Engine instances.<br>- Applicable in mode `dns`. |
 | MIRA_ENGINE_API_PORT_LABEL            | qix-engine-api-port     | Label that Mira uses to determine the QIX API (websocket) port.<br/>- Applicable in modes `swarm`, `kubernetes`, and `local`. |
 | MIRA_ENGINE_METRICS_PORT_LABEL        | qix-engine-metrics-port | Label that Mira uses to determine the `/metrics` port.<br/>- Applicable in modes `swarm`, `kubernetes`, and `local`. |
-| MIRA_KUBERNETES_TARGET_NAMESPACE      | n/a                     | Namespace that Mira looks for Qlik Associative Engines in. If not set Mira will look into all namespaces. <br/>- Applicable in modes `kubernetes`. |
+| MIRA_KUBERNETES_TARGET_NAMESPACE      | n/a                     | Namespace that Mira looks for Qlik Associative Engines in. If not set Mira will look into all namespaces. <br/>- Applicable in mode `kubernetes`. |
 | MIRA_ENGINE_DISCOVERY_INTERVAL        | 10000                   | Interval in milliseconds for discovering Qlik Associative Engine instances. |
 | MIRA_ENGINE_UPDATE_INTERVAL           | 10000                   | Interval in milliseconds for updating health and metrics for Qlik Associative Engine instances. |
 | MIRA_KUBERNETES_PROXY_PORT            | 8001                    | Port that Mira uses to communicate with the Kubernetes API server. |
@@ -54,8 +54,8 @@ Mira supports the following operation modes:
 |[Local](#local-mode)                   | Discovers Qlik Associative Engine instances running on the local Docker Engine.       |
 
 To set the operation mode, define the environment variable `MIRA_MODE` on the Mira container.
-In `Local` or `Swarm` mode you will also have to set the running user to `root` in your `docker-compose.yml` file.
-This is needed to be able to mount the `docker.sock` which is used to talk to the Docker API in `Local` and `Swarm` mode.
+In `local` or `swarm` mode you will also have to set the running user to `root` in your `docker-compose.yml` file.
+This is needed to be able to mount the `docker.sock` which is used to talk to the Docker API in `local` and `swarm` mode.
 
 ### Qlik Associative Engine labeling
 
@@ -107,7 +107,7 @@ How Mira should access the Docker Remote API can be configured in two ways.
 
 Mount `docker.sock` as a volume into the Mira container as shown in this [example](https://github.com/qlik-oss/mira/blob/master/docker-compose.yml).
 It is however only possible to mount `docker.sock` on a Swarm manager node. To be able to mount the local `docker.sock`
-Mira must be run with the `root` user configured in the `docker-compose.yml` file
+Mira must be run with the `root` user configured in the `docker-compose.yml` file.
 
 If Mira should be running on a worker node Mira needs to be configured to access the Docker Remote API by a URL.
 In this case there is no need to mount `docker.sock` into the Mira container,
@@ -366,7 +366,7 @@ that are running on the `localhost` Docker Engine, without any orchestration pla
 
 You can enable _Local_ mode by setting the `MIRA_MODE` environment variable to `local`
 before you start the Mira Docker container.
-You also need to set mira to run as the `root` user in your `docker-compose.yml` file
+You also need to set Mira to run as the `root` user in your `docker-compose.yml` file.
 
 ### Example of Local mode
 

--- a/docs/services/mira.md
+++ b/docs/services/mira.md
@@ -32,8 +32,9 @@ The following environment variables can optionally be set:
 | MIRA_DISCOVERY_HOSTNAME               | n/a                     | Hostname that Mira uses to query DNS for Qlik Associative Engine instances.<br>- Applicable in mode `dns`. |
 | MIRA_ENGINE_API_PORT_LABEL            | qix-engine-api-port     | Label that Mira uses to determine the QIX API (websocket) port.<br/>- Applicable in modes `swarm`, `kubernetes`, and `local`. |
 | MIRA_ENGINE_METRICS_PORT_LABEL        | qix-engine-metrics-port | Label that Mira uses to determine the `/metrics` port.<br/>- Applicable in modes `swarm`, `kubernetes`, and `local`. |
-| MIRA_ENGINE_DISCOVERY_INTERVAL        | 10000                    | Interval in milliseconds for discovering Qlik Associative Engine instances. |
-| MIRA_ENGINE_UPDATE_INTERVAL           | 10000                    | Interval in milliseconds for updating health and metrics for Qlik Associative Engine instances. |
+| MIRA_KUBERNETES_TARGET_NAMESPACE      | n/a                     | Namespace that Mira looks for Qlik Associative Engines in. If not set Mira will look into all namespaces. <br/>- Applicable in modes `kubernetes`. |
+| MIRA_ENGINE_DISCOVERY_INTERVAL        | 10000                   | Interval in milliseconds for discovering Qlik Associative Engine instances. |
+| MIRA_ENGINE_UPDATE_INTERVAL           | 10000                   | Interval in milliseconds for updating health and metrics for Qlik Associative Engine instances. |
 | MIRA_KUBERNETES_PROXY_PORT            | 8001                    | Port that Mira uses to communicate with the Kubernetes API server. |
 | MIRA_LOG_LEVEL                        | info                    | Minimum log level that Mira outputs when logging to `stdout`. |
 | MIRA_ALLOWED_RESPONSE_TIME            | 1                       | Maximum allowed time in seconds from when a request is received until a response is being sent. |
@@ -50,10 +51,11 @@ Mira supports the following operation modes:
 |[Swarm](#swarm-mode)                   | Discovers Qlik Associative Engine instances in a Docker Swarm environment.            |
 |[Kubernetes](#kubernetes-mode)         | Discovers Qlik Associative Engine instances in a Kubernetes environment.              |
 |[DNS](#dns-mode)                       | Discovers Qlik Associative Engine instances using DNS service look-ups.               |
-|[Local](#local-mode)                   | Discovers Qlik Associative Engine instances running on the local Docker Engine.        |
+|[Local](#local-mode)                   | Discovers Qlik Associative Engine instances running on the local Docker Engine.       |
 
 To set the operation mode, define the environment variable `MIRA_MODE` on the Mira container.
-In `Local` or `Swarm` mode you will also have to set the running user to `root` in your `docker-compose.yml` file
+In `Local` or `Swarm` mode you will also have to set the running user to `root` in your `docker-compose.yml` file.
+This is needed to be able to mount the `docker.sock` which is used to talk to the Docker API in `Local` and `Swarm` mode.
 
 ### Qlik Associative Engine labeling
 
@@ -104,8 +106,8 @@ In _Swarm_ mode Mira communicates with Docker Remote API to discover Qlik Associ
 How Mira should access the Docker Remote API can be configured in two ways.
 
 Mount `docker.sock` as a volume into the Mira container as shown in this [example](https://github.com/qlik-oss/mira/blob/master/docker-compose.yml).
-It is however only possible to mount `docker.sock` on a Swarm manager node. To be able to mount the `docker.sock`
-mira must be run with the `root` user configured in the `docker-compose.yml` file
+It is however only possible to mount `docker.sock` on a Swarm manager node. To be able to mount the local `docker.sock`
+Mira must be run with the `root` user configured in the `docker-compose.yml` file
 
 If Mira should be running on a worker node Mira needs to be configured to access the Docker Remote API by a URL.
 In this case there is no need to mount `docker.sock` into the Mira container,
@@ -208,6 +210,8 @@ before starting the Mira pod.
 !!! Note
     Mira uses the Kubernetes API to discover Qlik Associative Engines in a Kubernetes deployment.
     If RBAC is enabled in Kubernetes then Mira will need `view` access to the Kubernetes API.
+    If `MIRA_KUBERNETES_TARGET_NAMESPACE`
+    is set however it is enough to give Mira `view` access to the API for that specific namespace.
 
 ### Example of Kubernetes mode
 

--- a/docs/services/mira.md
+++ b/docs/services/mira.md
@@ -104,7 +104,8 @@ In _Swarm_ mode Mira communicates with Docker Remote API to discover Qlik Associ
 How Mira should access the Docker Remote API can be configured in two ways.
 
 Mount `docker.sock` as a volume into the Mira container as shown in this [example](https://github.com/qlik-oss/mira/blob/master/docker-compose.yml).
-It is however only possible to mount `docker.sock` on a Swarm manager node. To be able to mount the `docker.sock` mira must be run with the `root` user configured in the `docker-compose.yml` file
+It is however only possible to mount `docker.sock` on a Swarm manager node. To be able to mount the `docker.sock`
+mira must be run with the `root` user configured in the `docker-compose.yml` file
 
 If Mira should be running on a worker node Mira needs to be configured to access the Docker Remote API by a URL.
 In this case there is no need to mount `docker.sock` into the Mira container,
@@ -360,7 +361,8 @@ When Mira is running in _Local_ mode, Mira looks for Qlik Associative Engine ins
 that are running on the `localhost` Docker Engine, without any orchestration platform such as Docker Swarm or Kubernetes.
 
 You can enable _Local_ mode by setting the `MIRA_MODE` environment variable to `local`
-before you start the Mira Docker container. You also need to set mira to run as the `root` user in your `docker-compose.yml` file
+before you start the Mira Docker container.
+You also need to set mira to run as the `root` user in your `docker-compose.yml` file
 
 ### Example of Local mode
 

--- a/docs/services/mira.md
+++ b/docs/services/mira.md
@@ -53,6 +53,7 @@ Mira supports the following operation modes:
 |[Local](#local-mode)                   | Discovers Qlik Associative Engine instances running on the local Docker Engine.        |
 
 To set the operation mode, define the environment variable `MIRA_MODE` on the Mira container.
+In `Local` or `Swarm` mode you will also have to set the running user to `root` in your `docker-compose.yml` file
 
 ### Qlik Associative Engine labeling
 
@@ -103,7 +104,7 @@ In _Swarm_ mode Mira communicates with Docker Remote API to discover Qlik Associ
 How Mira should access the Docker Remote API can be configured in two ways.
 
 Mount `docker.sock` as a volume into the Mira container as shown in this [example](https://github.com/qlik-oss/mira/blob/master/docker-compose.yml).
-It is however only possible to mount `docker.sock` on a Swarm manager node.
+It is however only possible to mount `docker.sock` on a Swarm manager node. To be able to mount the `docker.sock` mira must be run with the `root` user configured in the `docker-compose.yml` file
 
 If Mira should be running on a worker node Mira needs to be configured to access the Docker Remote API by a URL.
 In this case there is no need to mount `docker.sock` into the Mira container,
@@ -153,6 +154,7 @@ version: "3.1"
 services:
   mira:
     image: qlikcore/mira
+    user: root
     environment:
      - MIRA_MODE=swarm
     ...
@@ -358,7 +360,7 @@ When Mira is running in _Local_ mode, Mira looks for Qlik Associative Engine ins
 that are running on the `localhost` Docker Engine, without any orchestration platform such as Docker Swarm or Kubernetes.
 
 You can enable _Local_ mode by setting the `MIRA_MODE` environment variable to `local`
-before you start the Mira Docker container.
+before you start the Mira Docker container. You also need to set mira to run as the `root` user in your `docker-compose.yml` file
 
 ### Example of Local mode
 
@@ -388,6 +390,7 @@ version: "3.1"
 
 services:
   mira:
+    user: root
     image: qlikcore/mira
     ...
 

--- a/docs/tutorials/orchestration.md
+++ b/docs/tutorials/orchestration.md
@@ -80,7 +80,7 @@ The stack consists of one Qlik Associative Engine, one Mira discovery service, a
 
 #### Placement constraints
 
-The Mira service is placed on the swarm manager node
+The Mira service is placed on the swarm manager node and run as the `root` user
 so that it can communicate with the manager Docker Engine.
 This is why `/var/run/docker.sock` is mounted into the service.
 


### PR DESCRIPTION
Changes in the documentation about having to specify the root user when running `mira` in `local` or `swarm` mode.

We will also need to update information about `mira` being able to only check for engines in a specified namespace, which is something Louis is working on.